### PR TITLE
fix(frontend): eliminate clock drift via timestamp anchor

### DIFF
--- a/frontend/src/components/Clock.jsx
+++ b/frontend/src/components/Clock.jsx
@@ -52,13 +52,20 @@ export function Clock({ serverMs, active, label }) {
   }, [active]);
 
   // While running, schedule re-renders for smooth display. The value itself is
-  // always derived from the anchor — this loop only paints.
+  // always derived from the anchor — this loop only paints. Stop scheduling
+  // once the clock is exhausted: the displayed value is already clamped to 0
+  // and continuing to repaint would just burn CPU/battery until the server's
+  // game_over message arrives and flips `active` false.
   useEffect(() => {
     if (!active) return;
     let raf;
     const loop = () => {
+      const a = anchorRef.current;
+      const remaining = Math.max(0, a.ms - (a.running ? performance.now() - a.t : 0));
       rerender();
-      raf = requestAnimationFrame(loop);
+      if (a.running && remaining > 0) {
+        raf = requestAnimationFrame(loop);
+      }
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);


### PR DESCRIPTION
## Problem

The local clock countdown drifted noticeably from the server's authoritative value during gameplay — the displayed time stayed too high and then jumped down by up to ~17 seconds when a `state_update` arrived after a move.

## Root cause

`Clock.jsx` accumulated countdown time into React state via a `requestAnimationFrame` loop:

```js
setDisplayMs(prev => Math.max(0, prev - (now - lastTickRef.current)))
```

Two compounding bugs:

1. **Lost tick on every server update.** `useEffect([serverMs])` reset `lastTickRef.current = null` on every authoritative refresh, so the very next rAF tick took the `if (lastTickRef.current !== null)` early-out and silently dropped ~16ms of countdown. Per move, per clock.
2. **Compounding drift.** Any missed frame, browser tab throttle, slow render, or parent re-render that briefly cancelled the rAF chain (via the `[active]` cleanup) caused the loss to *accumulate forever*, because the previous (already-drifted) `displayMs` was always the baseline for the next decrement.

State-based delta accumulation in a rAF loop is inherently fragile in React — any disturbance to the loop becomes permanent drift.

## Fix

Stop accumulating. Snapshot the authoritative value into a ref as ``{ ms, t, running }`` and **derive** the displayed value freshly on every render:

```js
displayMs = anchor.ms - (anchor.running ? performance.now() - anchor.t : 0)
```

`requestAnimationFrame` now only schedules re-renders — it never mutates state. Missed/delayed frames affect smoothness only, never correctness. The clock tracks wall-clock time exactly.

The anchor is re-snapshotted in two cases:
- **`serverMs` change** — authoritative refresh from a state_update.
- **`active` flip** — captures the currently displayed value so the clock freezes (or unfreezes) cleanly even when no fresh `serverMs` accompanies the flip (e.g. game ends mid-think).

Server-side clock logic in ``services/game/src/clockManager.js`` is unchanged — it was already correct.

## Test plan

- [ ] Play a real-time game and watch the player clock — countdown should be smooth and match server values within network latency (~tens of ms) on every state_update, no visible jumps.
- [ ] Background the tab during the opponent's turn for >5s, then refocus — opponent's clock should reflect the actual elapsed time, not pause.
- [ ] Trigger draw offer / overlay / panel-switch interactions during your own turn — clock countdown must not pause or jump.
- [ ] Run out of time on purpose — final value should be 0:00.0 with no overshoot.
- [ ] Resign mid-think — clock should freeze at the displayed value, not snap back up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Smoother, more consistent countdown rendering for the Clock component.
  * Countdown remains accurate despite frame drops or browser throttling.
  * Activating/deactivating the clock immediately freezes or unfreezes the displayed time.
  * Server-provided time updates are reflected instantly in the displayed countdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->