### PR TITLE
design(frontend): tighten corner radius scale across the app

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -221,7 +221,7 @@ export default function App() {
   const challengeBanner = notifications.length > 0 && (
     <div className="fixed bottom-6 right-6 flex flex-col gap-2 z-[200] max-w-sm w-full">
       {notifications.map((n) => (
-        <div key={n.id} className="flex items-center gap-3 bg-white rounded-xl px-4 py-3.5 shadow-[0_8px_32px_rgba(0,0,0,0.12)] border border-surface-high">
+        <div key={n.id} className="flex items-center gap-3 bg-white rounded-md px-4 py-3.5 shadow-[0_8px_32px_rgba(0,0,0,0.12)] border border-surface-high">
           <div className="flex flex-col gap-0.5 flex-1 min-w-0">
             <span className="font-display font-bold text-sm text-on-surface">{n.from_name} challenged you!</span>
             <span className="font-mono text-[0.7rem] text-muted">{n.time_control} · Accept to start</span>
@@ -260,7 +260,7 @@ export default function App() {
             <span className="font-display font-extrabold text-lg tracking-[-0.02em] text-white/80">FF</span>
 
             <div className="max-w-lg">
-              <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/10 rounded-full px-4 py-1.5 mb-8">
+              <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/10 rounded-md px-4 py-1.5 mb-8">
                 <span className="text-white/60 font-mono text-[0.65rem] uppercase tracking-[0.1em]">Glicko-2 Rated</span>
                 <span className="w-1 h-1 rounded-full bg-white/30" />
                 <span className="text-white/60 font-mono text-[0.65rem] uppercase tracking-[0.1em]">Live Games</span>
@@ -301,7 +301,7 @@ export default function App() {
                 <div className="flex flex-col gap-1.5">
                   <label className="font-body text-xs font-semibold text-muted uppercase tracking-[0.07em]">Display name</label>
                   <input
-                    className="w-full px-5 py-3.5 bg-surface rounded-xl border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface placeholder:text-muted/50 transition-all"
+                    className="w-full px-5 py-3.5 bg-surface rounded-md border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface placeholder:text-muted/50 transition-all"
                     placeholder="Magnus"
                     value={authForm.displayName}
                     onChange={(e) => setAuthForm((f) => ({ ...f, displayName: e.target.value }))}
@@ -313,7 +313,7 @@ export default function App() {
               <div className="flex flex-col gap-1.5">
                 <label className="font-body text-xs font-semibold text-muted uppercase tracking-[0.07em]">Email address</label>
                 <input
-                  className="w-full px-5 py-3.5 bg-surface rounded-xl border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface placeholder:text-muted/50 transition-all"
+                  className="w-full px-5 py-3.5 bg-surface rounded-md border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface placeholder:text-muted/50 transition-all"
                   type="email"
                   placeholder="you@example.com"
                   value={authForm.email}
@@ -325,7 +325,7 @@ export default function App() {
               <div className="flex flex-col gap-1.5">
                 <label className="font-body text-xs font-semibold text-muted uppercase tracking-[0.07em]">Password</label>
                 <input
-                  className="w-full px-5 py-3.5 bg-surface rounded-xl border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface transition-all"
+                  className="w-full px-5 py-3.5 bg-surface rounded-md border border-surface-high outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-body text-sm text-on-surface transition-all"
                   type="password"
                   placeholder="••••••••"
                   value={authForm.password}
@@ -336,11 +336,11 @@ export default function App() {
               </div>
 
               {authError && (
-                <p className="font-mono text-xs text-danger bg-danger-bg rounded-xl px-4 py-2.5">{authError}</p>
+                <p className="font-mono text-xs text-danger bg-danger-bg rounded-md px-4 py-2.5">{authError}</p>
               )}
 
               <button
-                className="w-full py-3.5 bg-primary text-on-primary rounded-full font-display font-bold text-sm tracking-[-0.01em] shadow-lg shadow-primary/20 hover:opacity-90 active:scale-[0.98] transition-all mt-1 border-0 cursor-pointer disabled:opacity-50"
+                className="w-full py-3.5 bg-primary text-on-primary rounded-md font-display font-bold text-sm tracking-[-0.01em] shadow-lg shadow-primary/20 hover:opacity-90 active:scale-[0.98] transition-all mt-1 border-0 cursor-pointer disabled:opacity-50"
                 type="submit"
                 disabled={authLoading}
               >
@@ -392,7 +392,7 @@ export default function App() {
               <span className="font-display font-extrabold text-sm tracking-[-0.01em] text-on-surface">Fianchetto Friends</span>
             </div>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-xl bg-primary flex items-center justify-center text-on-primary font-display font-extrabold text-base flex-shrink-0 shadow-lg shadow-primary/30">
+              <div className="w-10 h-10 rounded-md bg-primary flex items-center justify-center text-on-primary font-display font-extrabold text-base flex-shrink-0 shadow-lg shadow-primary/30">
                 {(user?.display_name ?? '?')[0].toUpperCase()}
               </div>
               <div className="min-w-0">
@@ -411,7 +411,7 @@ export default function App() {
                 key={key}
                 onClick={() => setLobbyTab(key)}
                 className={[
-                  'flex items-center gap-3 py-3 px-3 rounded-xl text-left w-full transition-all duration-150 border-0 cursor-pointer',
+                  'flex items-center gap-3 py-3 px-3 rounded-md text-left w-full transition-all duration-150 border-0 cursor-pointer',
                   lobbyTab === key
                     ? 'bg-primary text-on-primary shadow-sm'
                     : 'bg-transparent text-muted hover:bg-black/[0.05] hover:text-on-surface',
@@ -427,7 +427,7 @@ export default function App() {
           <div className="px-3 pb-6 pt-3 border-t border-black/[0.06]">
             <button
               onClick={handleLogout}
-              className="flex items-center gap-3 py-3 px-3 rounded-xl text-left w-full transition-all border-0 cursor-pointer text-muted hover:bg-black/[0.05] hover:text-danger"
+              className="flex items-center gap-3 py-3 px-3 rounded-md text-left w-full transition-all border-0 cursor-pointer text-muted hover:bg-black/[0.05] hover:text-danger"
             >
               <span className="w-5 text-center text-sm leading-none flex-shrink-0">↩</span>
               <span className="font-body text-xs font-semibold uppercase tracking-[0.07em]">Sign out</span>
@@ -464,7 +464,7 @@ export default function App() {
               <button
                 onClick={handleCreateInvite}
                 disabled={creatingInvite}
-                className="flex items-center gap-1.5 bg-primary text-on-primary rounded-full px-5 py-2.5 font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.97] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
+                className="flex items-center gap-1.5 bg-primary text-on-primary rounded-md px-5 py-2.5 font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.97] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
               >
                 <span className="text-lg leading-none">+</span> New Game
               </button>
@@ -509,7 +509,7 @@ export default function App() {
               <div className="max-w-[1100px] mx-auto grid grid-cols-12 gap-6">
 
                 {/* Match card */}
-                <section className="col-span-12 lg:col-span-7 bg-white rounded-2xl shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
+                <section className="col-span-12 lg:col-span-7 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
                   <p className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.1em] mb-1">
                     {createdInvite ? 'Share with your opponent' : 'Start a game'}
                   </p>
@@ -519,14 +519,14 @@ export default function App() {
 
                   {createdInvite ? (
                     <div className="flex flex-col gap-4">
-                      <div className="flex items-center gap-3 p-4 bg-[#f1f2f4] rounded-2xl">
+                      <div className="flex items-center gap-3 p-4 bg-[#f1f2f4] rounded-md">
                         <span className="font-mono text-xs text-on-surface flex-1 break-all leading-relaxed">
                           {`${location.origin}/play/${createdInvite.token}`}
                         </span>
                         <button
                           onClick={handleCopyLink}
                           className={[
-                            'font-mono text-xs font-bold px-4 py-2 rounded-full border-0 cursor-pointer whitespace-nowrap transition-all flex-shrink-0',
+                            'font-mono text-xs font-bold px-4 py-2 rounded-md border-0 cursor-pointer whitespace-nowrap transition-all flex-shrink-0',
                             copied ? 'bg-success-bg text-success' : 'bg-primary text-on-primary hover:opacity-80',
                           ].join(' ')}
                         >{copied ? '✓ Copied' : 'Copy link'}</button>
@@ -567,7 +567,7 @@ export default function App() {
                       </div>
 
                       {/* Custom TC */}
-                      <div className="flex items-center gap-3 mb-5 p-3 bg-[#f1f2f4] rounded-xl">
+                      <div className="flex items-center gap-3 mb-5 p-3 bg-[#f1f2f4] rounded-md">
                         <span className="font-mono text-[0.62rem] text-muted uppercase tracking-[0.07em] whitespace-nowrap">Custom:</span>
                         <select
                           className="flex-1 bg-transparent border-0 outline-none font-body text-sm text-on-surface cursor-pointer"
@@ -585,11 +585,11 @@ export default function App() {
                       </div>
 
                       {lobbyError && (
-                        <p className="font-mono text-xs text-danger bg-danger-bg rounded-xl px-4 py-2.5 mb-4">{lobbyError}</p>
+                        <p className="font-mono text-xs text-danger bg-danger-bg rounded-md px-4 py-2.5 mb-4">{lobbyError}</p>
                       )}
 
                       <button
-                        className="w-full py-3.5 bg-primary text-on-primary rounded-full font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
+                        className="w-full py-3.5 bg-primary text-on-primary rounded-md font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
                         onClick={handleCreateInvite}
                         disabled={creatingInvite}
                       >
@@ -600,18 +600,18 @@ export default function App() {
                 </section>
 
                 {/* Profile ratings card */}
-                <section className="col-span-12 lg:col-span-5 bg-white rounded-2xl shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] overflow-hidden">
+                <section className="col-span-12 lg:col-span-5 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] overflow-hidden">
                   <ProfilePanel token={token} user={user} />
                 </section>
 
                 {/* Join game strip */}
-                <section className="col-span-12 bg-white rounded-2xl shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] px-8 py-6">
+                <section className="col-span-12 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] px-8 py-6">
                   <h2 className="font-display font-bold text-base text-on-surface mb-4">Join a game</h2>
                   <form onSubmit={handleJoin} className="flex items-end gap-3">
                     <div className="flex flex-col gap-1.5 flex-1">
                       <label className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.07em]">Invite token or game ID</label>
                       <input
-                        className="px-4 py-3 bg-[#f1f2f4] rounded-xl border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
+                        className="px-4 py-3 bg-[#f1f2f4] rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
                         placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                         value={joinInput}
                         onChange={(e) => setJoinInput(e.target.value)}
@@ -619,7 +619,7 @@ export default function App() {
                       />
                     </div>
                     <button
-                      className="py-3 px-6 bg-on-surface text-white rounded-full font-display font-bold text-sm border-0 cursor-pointer hover:opacity-80 transition-all whitespace-nowrap disabled:opacity-50 flex-shrink-0"
+                      className="py-3 px-6 bg-on-surface text-white rounded-md font-display font-bold text-sm border-0 cursor-pointer hover:opacity-80 transition-all whitespace-nowrap disabled:opacity-50 flex-shrink-0"
                       type="submit"
                       disabled={joiningGame}
                     >
@@ -648,7 +648,7 @@ export default function App() {
             {/* ── Analyze tab — paste a PGN ── */}
             {!viewingGameId && !pgnReviewData && lobbyTab === 'analyze' && (
               <div className="max-w-2xl mx-auto">
-                <div className="bg-white rounded-2xl shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
+                <div className="bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
                   <p className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.1em] mb-1">
                     Paste a PGN
                   </p>
@@ -660,19 +660,19 @@ export default function App() {
                   </p>
                   <textarea
                     aria-labelledby="analyze-heading"
-                    className="w-full min-h-[260px] px-4 py-3 bg-[#f1f2f4] rounded-xl border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all resize-y"
+                    className="w-full min-h-[260px] px-4 py-3 bg-[#f1f2f4] rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all resize-y"
                     placeholder={'[Event "Casual game"]\n[White "Player A"]\n[Black "Player B"]\n[Result "1-0"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 ...'}
                     value={pgnInput}
                     onChange={(e) => { setPgnInput(e.target.value); setPgnError(''); }}
                     spellCheck={false}
                   />
                   {pgnError && (
-                    <p className="font-mono text-xs text-danger bg-danger-bg rounded-xl px-4 py-2.5 mt-4">{pgnError}</p>
+                    <p className="font-mono text-xs text-danger bg-danger-bg rounded-md px-4 py-2.5 mt-4">{pgnError}</p>
                   )}
                   <button
                     onClick={handleAnalyzePgn}
                     disabled={!pgnInput.trim()}
-                    className="mt-5 w-full py-3.5 bg-primary text-on-primary rounded-full font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
+                    className="mt-5 w-full py-3.5 bg-primary text-on-primary rounded-md font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
                   >
                     Analyze →
                   </button>
@@ -724,21 +724,21 @@ export default function App() {
         </div>
         <div className="flex items-center gap-3">
           <button
-            className="font-body text-sm font-medium text-muted hover:text-on-surface bg-transparent border-0 cursor-pointer transition-colors disabled:opacity-30 px-3 py-1.5 rounded-xl hover:bg-surface-high"
+            className="font-body text-sm font-medium text-muted hover:text-on-surface bg-transparent border-0 cursor-pointer transition-colors disabled:opacity-30 px-3 py-1.5 rounded-md hover:bg-surface-high"
             onClick={sendDrawOffer}
             disabled={!!gameOver}
           >
             Offer draw
           </button>
           <button
-            className="font-body text-sm font-medium text-danger hover:bg-danger-bg bg-transparent border border-danger/20 cursor-pointer transition-all disabled:opacity-30 px-3 py-1.5 rounded-xl"
+            className="font-body text-sm font-medium text-danger hover:bg-danger-bg bg-transparent border border-danger/20 cursor-pointer transition-all disabled:opacity-30 px-3 py-1.5 rounded-md"
             onClick={sendResign}
             disabled={!!gameOver}
           >
             Resign
           </button>
           <div className={[
-            'flex items-center gap-1.5 font-mono text-xs font-medium px-3 py-1.5 rounded-full',
+            'flex items-center gap-1.5 font-mono text-xs font-medium px-3 py-1.5 rounded-md',
             connected ? 'bg-success-bg text-success' : 'bg-surface-high text-muted',
           ].join(' ')}>
             <div className={['w-1.5 h-1.5 rounded-full', connected ? 'bg-success animate-pulse' : 'bg-muted'].join(' ')} />
@@ -838,7 +838,7 @@ export default function App() {
 function Overlay({ children }) {
   return (
     <div className="fixed inset-0 bg-surface-low/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl p-8 shadow-[0_24px_64px_rgba(0,0,0,0.12)] max-w-sm w-full flex flex-col gap-2">
+      <div className="bg-white rounded-md p-8 shadow-[0_24px_64px_rgba(0,0,0,0.12)] max-w-sm w-full flex flex-col gap-2">
         {children}
       </div>
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -392,7 +392,7 @@ export default function App() {
               <span className="font-display font-extrabold text-sm tracking-[-0.01em] text-on-surface">Fianchetto Friends</span>
             </div>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-md bg-primary flex items-center justify-center text-on-primary font-display font-extrabold text-base flex-shrink-0 shadow-lg shadow-primary/30">
+              <div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center text-on-primary font-display font-extrabold text-base flex-shrink-0 shadow-lg shadow-primary/30">
                 {(user?.display_name ?? '?')[0].toUpperCase()}
               </div>
               <div className="min-w-0">

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -25,7 +25,7 @@ export function Board({ fen, playerColour, onMove, gameOver, animated = true, ma
 
   return (
     <div
-      className="bg-white rounded-2xl p-3 shadow-[0_8px_40px_rgba(0,0,0,0.10)] w-full border border-surface-high"
+      className="bg-white rounded-md p-3 shadow-[0_8px_40px_rgba(0,0,0,0.10)] w-full border border-surface-high"
       style={{ maxWidth }}
     >
       <Chessboard

--- a/frontend/src/components/Clock.jsx
+++ b/frontend/src/components/Clock.jsx
@@ -87,7 +87,7 @@ export function Clock({ serverMs, active, label }) {
 
   return (
     <div className={[
-      'flex flex-col gap-0.5 px-4 py-3 rounded-2xl min-w-[120px] transition-all duration-300',
+      'flex flex-col gap-0.5 px-4 py-3 rounded-md min-w-[120px] transition-all duration-300',
       active
         ? 'bg-white border border-surface-high shadow-[0_2px_12px_rgba(0,0,0,0.08)]'
         : 'bg-surface-low border border-transparent',

--- a/frontend/src/components/FriendsPanel.jsx
+++ b/frontend/src/components/FriendsPanel.jsx
@@ -110,7 +110,7 @@ export function FriendsPanel({ token, onChallengeAccepted }) {
   if (loading) return (
     <div className="flex flex-col gap-3">
       {[...Array(3)].map((_, i) => (
-        <div key={i} className="h-[60px] rounded-2xl bg-surface-high animate-pulse" />
+        <div key={i} className="h-[60px] rounded-md bg-surface-high animate-pulse" />
       ))}
     </div>
   );
@@ -120,14 +120,14 @@ export function FriendsPanel({ token, onChallengeAccepted }) {
 
       {/* Toast */}
       {actionMsg && (
-        <div className="font-mono text-[0.8rem] bg-success-bg text-success rounded-xl px-4 py-2.5 flex items-center gap-2">
+        <div className="font-mono text-[0.8rem] bg-success-bg text-success rounded-md px-4 py-2.5 flex items-center gap-2">
           <span>✓</span> {actionMsg}
         </div>
       )}
 
       {/* Challenge card */}
       {challenge && (
-        <div className="flex flex-col gap-3 bg-white rounded-2xl p-5 border border-primary/20 shadow-[0_2px_12px_rgba(0,90,183,0.08)]">
+        <div className="flex flex-col gap-3 bg-white rounded-md p-5 border border-primary/20 shadow-[0_2px_12px_rgba(0,90,183,0.08)]">
           {challenge.invite ? (
             <>
               <div className="flex items-center gap-2">
@@ -222,7 +222,7 @@ export function FriendsPanel({ token, onChallengeAccepted }) {
         </form>
 
         {searchErr && (
-          <p className="font-mono text-[0.8rem] text-danger bg-danger-bg rounded-xl px-3 py-2">{searchErr}</p>
+          <p className="font-mono text-[0.8rem] text-danger bg-danger-bg rounded-md px-3 py-2">{searchErr}</p>
         )}
 
         {results.map((u) => (
@@ -252,7 +252,7 @@ function SectionTitle({ children }) {
 function UserRow({ name, rating, sub, children }) {
   const initial = (name ?? '?')[0].toUpperCase();
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-2xl bg-white border border-surface-high shadow-[0_1px_4px_rgba(0,0,0,0.04)]">
+    <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md bg-white border border-surface-high shadow-[0_1px_4px_rgba(0,0,0,0.04)]">
       {/* Mini avatar + info */}
       <div className="flex items-center gap-3 flex-1 min-w-0">
         <div className="w-9 h-9 rounded-full bg-primary-gradient text-on-primary font-display font-bold text-sm flex items-center justify-center flex-shrink-0">

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -97,7 +97,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         <span className="font-display font-bold text-base text-on-surface">
           {data.game.white_name} vs {data.game.black_name}
         </span>
-        <span className="font-mono text-xs bg-[#f1f2f4] text-muted px-2.5 py-1 rounded-full">
+        <span className="font-mono text-xs bg-[#f1f2f4] text-muted px-2.5 py-1 rounded-sm">
           {data.game.time_control}
         </span>
         <span className="font-mono text-xs text-primary font-bold">{resultLabel}</span>
@@ -125,7 +125,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
   );
 
   const moveList = (
-    <div className="bg-white rounded-2xl border border-black/[0.04] p-4 h-full overflow-y-auto">
+    <div className="bg-white rounded-md border border-black/[0.04] p-4 h-full overflow-y-auto">
       {movePairs.length === 0 && (
         <p className="font-mono text-xs text-muted text-center py-4">No moves recorded</p>
       )}
@@ -190,7 +190,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
       className="fixed inset-0 bg-on-surface/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-surface rounded-2xl shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-3xl max-h-[92vh] flex flex-col overflow-hidden">
+      <div className="bg-surface rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-3xl max-h-[92vh] flex flex-col overflow-hidden">
         <div className="flex items-center justify-between px-5 py-4 bg-white border-b border-surface-high flex-shrink-0">
           {gameInfo ?? <div />}
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-high hover:bg-surface-highest text-muted border-0 cursor-pointer transition-colors flex-shrink-0 ml-3">✕</button>
@@ -214,7 +214,7 @@ function NavBtn({ children, onClick, disabled, title }) {
       onClick={onClick}
       disabled={disabled}
       title={title}
-      className="w-9 h-9 flex items-center justify-center rounded-xl bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
+      className="w-9 h-9 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
     >
       {children}
     </button>

--- a/frontend/src/components/HistoryPanel.jsx
+++ b/frontend/src/components/HistoryPanel.jsx
@@ -31,12 +31,12 @@ export function HistoryPanel({ token, userId, onViewGame, onViewProfile }) {
   if (loading && games.length === 0) return (
     <div className="flex flex-col gap-3">
       {[...Array(4)].map((_, i) => (
-        <div key={i} className="h-[68px] rounded-2xl bg-surface-high animate-pulse" />
+        <div key={i} className="h-[68px] rounded-md bg-surface-high animate-pulse" />
       ))}
     </div>
   );
   if (error) return (
-    <p className="font-mono text-sm text-danger bg-danger-bg rounded-xl px-4 py-3">{error}</p>
+    <p className="font-mono text-sm text-danger bg-danger-bg rounded-md px-4 py-3">{error}</p>
   );
   if (games.length === 0) return (
     <div className="flex flex-col items-center gap-3 py-16 text-center">
@@ -70,7 +70,7 @@ export function HistoryPanel({ token, userId, onViewGame, onViewProfile }) {
           <div
             key={g.id}
             onClick={() => onViewGame?.(g.id)}
-            className="flex items-stretch rounded-2xl bg-white border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all"
+            className="flex items-stretch rounded-md bg-white border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all"
           >
             {/* Left accent bar */}
             <div className={`w-1 flex-shrink-0 ${outcomeConfig.bar} opacity-80`} />

--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -24,13 +24,13 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
   }, [type, token]);
 
   const typeSelector = (
-    <div className="flex gap-1.5 p-1.5 bg-[#f1f2f4] rounded-2xl w-fit">
+    <div className="flex gap-1.5 p-1.5 bg-[#f1f2f4] rounded-md w-fit">
       {TYPES.map((t) => (
         <button
           key={t.key}
           onClick={() => setType(t.key)}
           className={[
-            'flex items-center gap-1.5 font-body text-sm px-4 py-2 rounded-xl border-0 cursor-pointer transition-all',
+            'flex items-center gap-1.5 font-body text-sm px-4 py-2 rounded-md border-0 cursor-pointer transition-all',
             type === t.key
               ? 'bg-white text-on-surface font-semibold shadow-sm'
               : 'bg-transparent text-muted hover:text-on-surface',
@@ -44,7 +44,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
   );
 
   const table = (
-    <div className="bg-white rounded-2xl border border-black/[0.04] overflow-hidden mt-5">
+    <div className="bg-white rounded-md border border-black/[0.04] overflow-hidden mt-5">
       {loading && (
         <div className="flex items-center justify-center py-12">
           <p className="font-body text-sm text-muted">Loading…</p>
@@ -113,7 +113,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
       className="fixed inset-0 bg-on-surface/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-surface rounded-2xl shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
+      <div className="bg-surface rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
         <div className="flex items-center justify-between px-5 py-4 bg-white border-b border-surface-high flex-shrink-0">
           <span className="font-display font-bold text-base text-on-surface">Leaderboard</span>
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-high hover:bg-surface-highest text-muted border-0 cursor-pointer transition-colors">✕</button>

--- a/frontend/src/components/PlayerProfile.jsx
+++ b/frontend/src/components/PlayerProfile.jsx
@@ -36,7 +36,7 @@ export function PlayerProfile({ userId, token, onClose, onViewGame }) {
       className="fixed inset-0 bg-on-surface/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-white rounded-2xl shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
+      <div className="bg-white rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
 
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-5 border-b border-surface-high flex-shrink-0">
@@ -62,7 +62,7 @@ export function PlayerProfile({ userId, token, onClose, onViewGame }) {
           {loading && (
             <div className="p-6 flex flex-col gap-3">
               {[...Array(3)].map((_, i) => (
-                <div key={i} className="h-12 rounded-2xl bg-surface-high animate-pulse" />
+                <div key={i} className="h-12 rounded-md bg-surface-high animate-pulse" />
               ))}
             </div>
           )}
@@ -80,7 +80,7 @@ export function PlayerProfile({ userId, token, onClose, onViewGame }) {
                   {TYPES.map((type) => {
                     const r = data.ratings[type];
                     return (
-                      <div key={type} className="bg-surface rounded-2xl px-4 py-3.5 border border-surface-high">
+                      <div key={type} className="bg-surface rounded-md px-4 py-3.5 border border-surface-high">
                         <div className="flex items-center gap-1.5 mb-1.5">
                           <span className="text-base leading-none">{ICONS[type]}</span>
                           <span className="font-mono text-[0.65rem] text-muted uppercase tracking-[0.06em] capitalize">
@@ -123,7 +123,7 @@ export function PlayerProfile({ userId, token, onClose, onViewGame }) {
                         <div
                           key={g.id}
                           onClick={() => onViewGame?.(g.id)}
-                          className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-surface border border-surface-high cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_8px_rgba(0,90,183,0.08)] transition-all"
+                          className="flex items-center gap-3 px-4 py-3 rounded-md bg-surface border border-surface-high cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_8px_rgba(0,90,183,0.08)] transition-all"
                         >
                           <span className={`font-mono text-[0.6rem] font-bold tracking-[0.06em] px-2.5 py-1.5 rounded-lg min-w-[44px] text-center flex-shrink-0 ${OUTCOME_STYLE[outcome]}`}>
                             {outcome.toUpperCase()}

--- a/frontend/src/components/ProfilePanel.jsx
+++ b/frontend/src/components/ProfilePanel.jsx
@@ -55,7 +55,7 @@ export function ProfilePanel({ token, user, onLogout = null }) {
                 key={type}
                 onClick={() => setSelectedType(type)}
                 className={[
-                  'flex flex-col gap-0.5 rounded-xl px-3 py-2.5 text-left border-0 cursor-pointer transition-all',
+                  'flex flex-col gap-0.5 rounded-md px-3 py-2.5 text-left border-0 cursor-pointer transition-all',
                   active
                     ? 'bg-primary/10 ring-1 ring-primary/30'
                     : 'bg-surface hover:bg-surface-high',
@@ -75,7 +75,7 @@ export function ProfilePanel({ token, user, onLogout = null }) {
 
         {/* Sparkline for the selected type */}
         {ratingHistory.length >= 2 && (
-          <div className="bg-surface rounded-xl px-3 py-2.5 border border-surface-high mt-1">
+          <div className="bg-surface rounded-md px-3 py-2.5 border border-surface-high mt-1">
             <span className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.06em]">
               {ICONS[selectedType]} {selectedType} history
             </span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,10 +40,15 @@
   --shadow-raised:  0 12px 40px rgba(25, 28, 30, 0.08);
   --shadow-float:   0 8px 40px rgba(25, 28, 30, 0.08);
 
-  /* Border radius */
-  --radius-sm: 0.5rem;
-  --radius-md: 0.75rem;
-  --radius-xl: 3rem;
+  /* Border radius — tight, modern scale.
+     `rounded-md` (8px) is the primary radius used by almost every surface
+     (cards, panels, buttons, inputs). `rounded-sm` (4px) is reserved for
+     small inline chips/badges. `rounded-lg` (12px) is for the few special
+     larger surfaces. Anything more pillowy than this should be reconsidered
+     before being added — see issue #8 for the rationale. */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
 }
 
 /* ── Base reset ──────────────────────────────────────────────────────────── */
@@ -85,13 +90,13 @@
 @layer components {
   .btn-primary {
     @apply font-display font-bold text-[0.9375rem] text-on-primary bg-primary-gradient
-           py-3 px-6 rounded-[3rem] border-0 cursor-pointer tracking-tight
+           py-3 px-6 rounded-md border-0 cursor-pointer tracking-tight
            transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-secondary {
     @apply font-body font-semibold text-[0.875rem] text-on-surface bg-surface-high
-           py-2 px-4 rounded-[3rem] border-0 cursor-pointer
+           py-2 px-4 rounded-md border-0 cursor-pointer
            transition-opacity hover:opacity-70 disabled:opacity-40;
   }
 
@@ -106,7 +111,7 @@
   }
 
   .text-input {
-    @apply font-body text-[0.9375rem] bg-surface-low rounded-xl border-0
+    @apply font-body text-[0.9375rem] bg-surface-low rounded-md border-0
            px-3.5 py-3 text-on-surface w-full transition-shadow;
   }
 


### PR DESCRIPTION
Closes #8

## Problem

The UI was visually soft to the point of feeling pillowy:

- Most surfaces used \`rounded-2xl\` (16px) or \`rounded-xl\` — and the \`index.css\` design tokens *overrode* \`--radius-xl\` to **3rem (48px)**, which made every input and small card essentially a full pill.
- 21 places used \`rounded-full\`, including the primary buttons (\`+ New Game\`, \`Analyze →\`, \`Create invite link\`, \`Join game →\`, \`Sign in\`), banners, and connection-status indicators — not just true circles.
- The \`.btn-primary\` and \`.btn-secondary\` utilities used a one-off \`rounded-[3rem]\` magic value that bypassed the token system entirely.

## Approach

A single design-pass commit, applied as two coordinated changes:

### 1. Tighten the design tokens in \`index.css\`

```css
@theme {
  --radius-sm: 0.25rem;   /* 4px  — chips, badges, small inline pills */
  --radius-md: 0.5rem;    /* 8px  — primary radius for cards/panels/buttons/inputs */
  --radius-lg: 0.75rem;   /* 12px — special larger surfaces */
}
```

The old \`--radius-xl: 3rem\` is **dropped** so any stray \`rounded-xl\` falls back to Tailwind's default 12px (still tighter than 48px). Updated \`.btn-primary\`, \`.btn-secondary\`, \`.text-input\` to use \`rounded-md\` — no more \`rounded-[3rem]\` magic numbers.

### 2. Replace heavy \`rounded-*\` classes throughout JSX

Mechanical replacements across 9 component files:

- \`rounded-2xl\` → \`rounded-md\` (cards, panels, modal containers)
- \`rounded-xl\`  → \`rounded-md\` (inputs, smaller cards, chips)
- \`rounded-full\` on **pill buttons / banners** → \`rounded-md\`
- \`rounded-full\` on the small \`time_control\` chip in the \`GameReview\` header → \`rounded-sm\`
- \`rounded-full\` on **true circles** → **kept as-is** (avatars, status dots, round close-buttons in review/profile/leaderboard panels)

The disambiguation rule for \`rounded-full\`: anything with explicit square \`w-X h-X\` dimensions is a true circle and stays. Anything else was a pill and got swapped.

## Before / after at a glance

| Surface                         | Before                | After       |
|---------------------------------|-----------------------|-------------|
| Primary CTA buttons             | \`rounded-full\` / \`rounded-[3rem]\` (48px) | \`rounded-md\` (8px) |
| Card containers                 | \`rounded-2xl\` (16px)  | \`rounded-md\` (8px) |
| Inputs                          | \`rounded-xl\` → 48px (token override) | \`rounded-md\` (8px) |
| Time-control chip               | \`rounded-full\`        | \`rounded-sm\` (4px) |
| Avatars / status dots           | \`rounded-full\`        | \`rounded-full\` (unchanged) |

## Verification

- \`npm run build\` succeeds locally; bundle size unchanged within rounding.
- \`grep\` confirms zero remaining \`rounded-2xl\` or \`rounded-xl\` in JSX.
- All 12 remaining \`rounded-full\` instances have explicit square \`w-X h-X\` dimensions (avatars, dots, close buttons).

## Test plan

- [ ] Lobby (Play tab) — primary "+ New Game" button, time-control cards, custom dropdown, and "Create invite link" CTA all show subtle rounded corners (8px), not pills.
- [ ] Sign-in / register screen — submit button is rounded-md, not pill.
- [ ] History tab — list rows / cards are tighter.
- [ ] Game review page — board card, eval bar wrapper, move list panel all use the new 8px radius. Time-control chip in the header is the smallest 4px chip.
- [ ] Friends panel — friend rows look sharper; avatars are still perfect circles.
- [ ] Profile + leaderboard — same.
- [ ] In-game play screen — clock cards, board card, header still functional. Avatars in headers stay circular.
- [ ] Modals (overlays / draw-offer) — corners look consistent with the rest.

## Out of scope

Color, typography, shadow / elevation — only corner radius this pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced border-radius across the app for a tighter, more consistent look—updated buttons, inputs, toasts, cards, modals, avatars, panels, and other UI containers to use smaller corner radii.
  * Adjusted design tokens for border-radius to standardize the new visual scale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->