### PR TITLE
fix(frontend): center eval label at split point and match bar height to board

### DIFF
--- a/frontend/src/components/EvalBar.jsx
+++ b/frontend/src/components/EvalBar.jsx
@@ -1,6 +1,9 @@
 /**
  * Vertical evaluation bar — white at the bottom, black at the top.
  * Eval is always from white's perspective (positive = white better).
+ * The numeric eval label floats at the dividing line between the two
+ * halves, so it's centered when the position is equal and tracks the
+ * split as the eval shifts.
  */
 export function EvalBar({ evaluation, orientation = 'white' }) {
   // Map centipawns to white's share of the bar (0–100%).
@@ -17,18 +20,21 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
   const topPct   = orientation === 'white' ? 100 - whitePct : whitePct;
   const bottomPct = 100 - topPct;
 
-  const evalText = () => {
+  const evalText = (() => {
     if (!evaluation) return '0.0';
     if (evaluation.mate !== null) return `M${Math.abs(evaluation.mate)}`;
     const abs = Math.abs(evaluation.cp / 100);
     return abs >= 10 ? Math.round(abs).toString() : abs.toFixed(1);
-  };
+  })();
 
   const whiteWinning = !evaluation
     || (evaluation.mate !== null ? evaluation.mate > 0 : evaluation.cp >= 0);
 
+  // Clamp the label so it doesn't overflow the bar at extreme evals.
+  const labelTop = Math.max(6, Math.min(94, topPct));
+
   return (
-    <div className="flex flex-col items-center gap-1 select-none" style={{ width: 22 }}>
+    <div className="flex flex-col items-center gap-1 select-none h-full" style={{ width: 28 }}>
       {/* Depth indicator */}
       {evaluation?.depth && (
         <span className="font-mono text-[0.5rem] text-muted leading-none">
@@ -36,29 +42,29 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
         </span>
       )}
 
-      {/* Bar */}
-      <div className="flex-1 w-full rounded overflow-hidden flex flex-col border border-black/10" style={{ minHeight: 200 }}>
+      {/* Bar — relative so the eval label can float at the split point */}
+      <div className="relative flex-1 w-full rounded-sm overflow-hidden flex flex-col border border-black/10">
         {/* Top portion (black's side) */}
         <div
-          className="bg-[#1c1c1c] transition-all duration-300 ease-out flex items-start justify-center pt-1"
+          className="bg-[#1c1c1c] transition-all duration-300 ease-out"
           style={{ height: `${topPct}%` }}
-        >
-          {!whiteWinning && (
-            <span className="font-mono text-[0.55rem] text-white/70 leading-none">
-              {evalText()}
-            </span>
-          )}
-        </div>
+        />
         {/* Bottom portion (white's side) */}
         <div
-          className="bg-[#f0f0f0] transition-all duration-300 ease-out flex items-end justify-center pb-1"
+          className="bg-[#f0f0f0] transition-all duration-300 ease-out"
           style={{ height: `${bottomPct}%` }}
+        />
+        {/* Eval label — centered at the split between black and white */}
+        <div
+          className="absolute inset-x-0 flex justify-center pointer-events-none transition-all duration-300 ease-out"
+          style={{ top: `${labelTop}%`, transform: 'translateY(-50%)' }}
         >
-          {whiteWinning && (
-            <span className="font-mono text-[0.55rem] text-black/50 leading-none">
-              {evalText()}
-            </span>
-          )}
+          <span className={[
+            'font-mono text-[0.55rem] font-semibold leading-none',
+            whiteWinning ? 'text-black/50' : 'text-white/70',
+          ].join(' ')}>
+            {evalText}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/EvalBar.jsx
+++ b/frontend/src/components/EvalBar.jsx
@@ -29,23 +29,20 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
     return abs >= 10 ? Math.round(abs).toString() : abs.toFixed(1);
   })();
 
-  const whiteWinning = !evaluation
-    || (evaluation.mate !== null ? evaluation.mate > 0 : evaluation.cp >= 0);
-
   // Clamp the label so it doesn't overflow the bar at extreme evals.
   const labelTop = Math.max(6, Math.min(94, topPct));
+  // Label color depends on which half it sits over, NOT on who's winning —
+  // orientation can flip the bar so whiteWinning alone would pick the wrong
+  // contrast. topPct > 50 means the dark (black) half is the majority and
+  // the label is in the dark zone.
+  const labelOnDark = topPct > 50;
 
   return (
-    <div className="flex flex-col items-center gap-1 select-none h-full" style={{ width: BAR_WIDTH }}>
-      {/* Depth indicator */}
-      {evaluation?.depth && (
-        <span className="font-mono text-[0.5rem] text-muted leading-none">
-          d{evaluation.depth}
-        </span>
-      )}
-
-      {/* Bar — relative so the eval label can float at the split point */}
-      <div className="relative flex-1 w-full rounded-sm overflow-hidden flex flex-col border border-black/10">
+    <div className="select-none h-full" style={{ width: BAR_WIDTH }}>
+      {/* Bar — owns the full stretched height. Depth badge and eval label
+          are absolutely positioned inside so they don't eat into the bar's
+          height (which must match the board exactly). */}
+      <div className="relative w-full h-full rounded-sm overflow-hidden flex flex-col border border-black/10">
         {/* Top portion (black's side) */}
         <div
           className="bg-[#1c1c1c] transition-all duration-300 ease-out"
@@ -56,6 +53,13 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
           className="bg-[#f0f0f0] transition-all duration-300 ease-out"
           style={{ height: `${bottomPct}%` }}
         />
+        {/* Depth indicator — absolutely positioned at the top so it doesn't
+            reduce the bar's height */}
+        {evaluation?.depth && (
+          <span className="absolute top-1 left-1/2 -translate-x-1/2 font-mono text-[0.5rem] text-white/50 leading-none pointer-events-none z-10">
+            d{evaluation.depth}
+          </span>
+        )}
         {/* Eval label — centered at the split between black and white */}
         <div
           className="absolute inset-x-0 flex justify-center pointer-events-none transition-all duration-300 ease-out"
@@ -63,7 +67,7 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
         >
           <span className={[
             'font-mono text-[0.55rem] font-semibold leading-none',
-            whiteWinning ? 'text-black/50' : 'text-white/70',
+            labelOnDark ? 'text-white/70' : 'text-black/50',
           ].join(' ')}>
             {evalText}
           </span>

--- a/frontend/src/components/EvalBar.jsx
+++ b/frontend/src/components/EvalBar.jsx
@@ -1,3 +1,5 @@
+const BAR_WIDTH = 28;
+
 /**
  * Vertical evaluation bar — white at the bottom, black at the top.
  * Eval is always from white's perspective (positive = white better).
@@ -34,7 +36,7 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
   const labelTop = Math.max(6, Math.min(94, topPct));
 
   return (
-    <div className="flex flex-col items-center gap-1 select-none h-full" style={{ width: 28 }}>
+    <div className="flex flex-col items-center gap-1 select-none h-full" style={{ width: BAR_WIDTH }}>
       {/* Depth indicator */}
       {evaluation?.depth && (
         <span className="font-mono text-[0.5rem] text-muted leading-none">

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -110,9 +110,9 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
     </div>
   );
 
-  const boardAndNav = (
-    <div className="flex flex-col items-center gap-4 w-full">
-      <Board fen={fen} playerColour="white" onMove={() => {}} gameOver={true} animated={false} maxWidth={680} />
+  // Shared navigation controls — used by both inline and modal layouts.
+  const navControls = (
+    <>
       <div className="flex items-center gap-2">
         <NavBtn onClick={() => setCursor(0)}                                      disabled={cursor === 0}     title="First (Home)">⏮</NavBtn>
         <NavBtn onClick={() => setCursor((c) => Math.max(0, c - 1))}              disabled={cursor === 0}     title="Previous (←)">◀</NavBtn>
@@ -121,6 +121,13 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         <NavBtn onClick={() => setCursor(total)}                                   disabled={cursor === total} title="Last (End)">⏭</NavBtn>
       </div>
       <p className="font-mono text-[0.65rem] text-muted/60">Use ← → arrow keys to navigate</p>
+    </>
+  );
+
+  const boardAndNav = (
+    <div className="flex flex-col items-center gap-4 w-full">
+      <Board fen={fen} playerColour="white" onMove={() => {}} gameOver={true} animated={false} maxWidth={680} />
+      {navControls}
     </div>
   );
 
@@ -170,14 +177,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
                   <Board fen={fen} playerColour="white" onMove={() => {}} gameOver={true} animated={false} maxWidth={680} />
                 </div>
                 {/* Navigation + tip below the board row */}
-                <div className="flex items-center gap-2">
-                  <NavBtn onClick={() => setCursor(0)}                                      disabled={cursor === 0}     title="First (Home)">⏮</NavBtn>
-                  <NavBtn onClick={() => setCursor((c) => Math.max(0, c - 1))}              disabled={cursor === 0}     title="Previous (←)">◀</NavBtn>
-                  <span className="font-mono text-sm text-muted w-20 text-center tabular-nums">{cursor} / {total}</span>
-                  <NavBtn onClick={() => setCursor((c) => Math.min(total, c + 1))}          disabled={cursor === total} title="Next (→)">▶</NavBtn>
-                  <NavBtn onClick={() => setCursor(total)}                                   disabled={cursor === total} title="Last (End)">⏭</NavBtn>
-                </div>
-                <p className="font-mono text-[0.65rem] text-muted/60">Use ← → arrow keys to navigate</p>
+                {navControls}
               </div>
               {/* Move list — fixed-width side panel */}
               <div className="w-full lg:w-80 flex-shrink-0">

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -158,22 +158,28 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         {data && (
           <>
             <div className="mb-6">{gameInfo}</div>
-            <div className="flex flex-col lg:flex-row gap-6 lg:items-stretch">
-              {/* Eval bar + board (dominant centerpiece) */}
-              <div className="flex gap-3 items-stretch flex-1 min-w-0 justify-center">
-                <div className="flex-shrink-0">
-                  <EvalBar evaluation={evaluation} orientation="white" />
+            <div className="flex flex-col lg:flex-row gap-6 lg:items-start">
+              {/* Board column — eval bar sits *next to the board*, not the
+                  entire nav stack, so its height matches the board exactly. */}
+              <div className="flex flex-col items-center gap-4 flex-1 min-w-0">
+                {/* Eval bar + board row */}
+                <div className="flex gap-3 items-stretch w-full justify-center">
+                  <div className="flex-shrink-0">
+                    <EvalBar evaluation={evaluation} orientation="white" />
+                  </div>
+                  <Board fen={fen} playerColour="white" onMove={() => {}} gameOver={true} animated={false} maxWidth={680} />
                 </div>
-                {/* Width cap is enforced by Board's `maxWidth` prop — no
-                    redundant Tailwind class here. */}
-                <div className="flex-1 min-w-0">
-                  {boardAndNav}
+                {/* Navigation + tip below the board row */}
+                <div className="flex items-center gap-2">
+                  <NavBtn onClick={() => setCursor(0)}                                      disabled={cursor === 0}     title="First (Home)">⏮</NavBtn>
+                  <NavBtn onClick={() => setCursor((c) => Math.max(0, c - 1))}              disabled={cursor === 0}     title="Previous (←)">◀</NavBtn>
+                  <span className="font-mono text-sm text-muted w-20 text-center tabular-nums">{cursor} / {total}</span>
+                  <NavBtn onClick={() => setCursor((c) => Math.min(total, c + 1))}          disabled={cursor === total} title="Next (→)">▶</NavBtn>
+                  <NavBtn onClick={() => setCursor(total)}                                   disabled={cursor === total} title="Last (End)">⏭</NavBtn>
                 </div>
+                <p className="font-mono text-[0.65rem] text-muted/60">Use ← → arrow keys to navigate</p>
               </div>
-              {/* Move list — fixed-width side panel. No explicit height: the
-                  parent's `lg:items-stretch` makes it grow to match the
-                  board's natural (square) height on every viewport, so the
-                  two columns can never desync. */}
+              {/* Move list — fixed-width side panel */}
               <div className="w-full lg:w-80 flex-shrink-0">
                 {moveList}
               </div>


### PR DESCRIPTION
## Problem

Two issues with the eval bar on the game review screen:

1. **Eval label position**: the numeric eval (e.g. "0.0", "+1.5") was pinned to the top/bottom edge of the bar — inside the winning side's section. So at an equal position the "0.0" label sat at the bottom of the bar, not in the center. Visually misleading.

2. **Bar height mismatch**: the eval bar was stretched to the height of the *entire* board-and-nav stack (board + navigation buttons + tip text), not just the board itself. The bar was noticeably taller than the board.

## Fix

### Eval label — float at the split point

Replace the edge-pinned labels with a single absolutely-positioned element at `top: ${topPct}%` with `translateY(-50%)`, so it floats at the dividing line between the black and white halves. At an equal eval the label is exactly centered; as the eval shifts the label tracks the split smoothly. Clamped to 6–94% so it doesn't overflow at extreme evaluations. Text color adapts automatically (dark on light half, light on dark half).

### Bar height — match the board exactly

Restructure the inline GameReview layout so the eval bar and the Board component are siblings in their own `items-stretch` flex-row, with navigation buttons and the keyboard-shortcut tip *below* that row in the outer column. The bar now matches the board's exact square height on every viewport. Added `h-full` on the EvalBar outer div so it fills its stretched container. Bumped bar width from 22px to 28px to give the label a bit more room.

## Test plan

- [ ] Open a game review → eval bar is the same height as the board, not taller.
- [ ] At the starting position (eval ~0.0) → the "0.0" label is centered in the bar.
- [ ] Step to a position where white is winning → label tracks upward with the split, text is dark on the white section.
- [ ] Step to a position where black is winning → label tracks downward, text is light on the dark section.
- [ ] At a forced mate → label shows "M1" / "M2" near the edge, still visible (not clipped).
- [ ] Navigation buttons and tip text sit below the board, not beside it.
- [ ] Modal-mode review (if reachable) still works — no eval bar, just board + nav as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Evaluation indicator now appears as a centered overlay on the board with clamped vertical positioning and contrast-aware text color for improved readability.
* **Refactor**
  * Game review layout reorganized: the evaluation bar is placed alongside the board in a unified row, navigation controls moved below, and the move list kept as a fixed-width side panel for more consistent layout and workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->