### PR TITLE
fix(frontend): pin eval label to center and smooth transitions

### DIFF
--- a/frontend/src/components/EvalBar.jsx
+++ b/frontend/src/components/EvalBar.jsx
@@ -3,9 +3,9 @@ const BAR_WIDTH = 28;
 /**
  * Vertical evaluation bar — white at the bottom, black at the top.
  * Eval is always from white's perspective (positive = white better).
- * The numeric eval label floats at the dividing line between the two
- * halves, so it's centered when the position is equal and tracks the
- * split as the eval shifts.
+ * The numeric eval label is fixed at the vertical center of the bar;
+ * the black/white split animates behind it. Text color adapts for
+ * contrast based on which half currently covers the center.
  */
 export function EvalBar({ evaluation, orientation = 'white' }) {
   // Map centipawns to white's share of the bar (0–100%).
@@ -29,12 +29,10 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
     return abs >= 10 ? Math.round(abs).toString() : abs.toFixed(1);
   })();
 
-  // Clamp the label so it doesn't overflow the bar at extreme evals.
-  const labelTop = Math.max(6, Math.min(94, topPct));
-  // Label color depends on which half it sits over, NOT on who's winning —
-  // orientation can flip the bar so whiteWinning alone would pick the wrong
-  // contrast. topPct > 50 means the dark (black) half is the majority and
-  // the label is in the dark zone.
+  // Label sits at the fixed vertical center (50%) of the bar — it never
+  // moves, only the split behind it shifts. Text color adapts to whichever
+  // half currently covers the center: dark (black) half is topPct% tall, so
+  // when topPct > 50 the center is inside the dark zone.
   const labelOnDark = topPct > 50;
 
   return (
@@ -60,11 +58,8 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
             d{evaluation.depth}
           </span>
         )}
-        {/* Eval label — centered at the split between black and white */}
-        <div
-          className="absolute inset-x-0 flex justify-center pointer-events-none transition-all duration-300 ease-out"
-          style={{ top: `${labelTop}%`, transform: 'translateY(-50%)' }}
-        >
+        {/* Eval label — fixed at the vertical center of the bar */}
+        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 flex justify-center pointer-events-none">
           <span className={[
             'font-mono text-[0.55rem] font-semibold leading-none',
             labelOnDark ? 'text-white/70' : 'text-black/50',

--- a/frontend/src/hooks/useStockfish.js
+++ b/frontend/src/hooks/useStockfish.js
@@ -86,7 +86,10 @@ export function useStockfish() {
     if (!worker || !ready) return;
 
     fenTurnRef.current = fen.split(' ')[1] ?? 'w';
-    setEvaluation(null);
+
+    // Don't clear evaluation to null here — the previous eval stays visible
+    // until the new search's first depth-4+ info line overwrites it. This
+    // avoids the jarring snap-to-center flash on every position change.
 
     // `ucinewgame` is intentionally NOT sent between positions: we're
     // analysing different positions of the same review session, not starting


### PR DESCRIPTION
Closes #11, closes #12

## Changes

Two atomic commits:

### 1. Keep previous eval visible while new analysis loads (closes #12)

`analyze()` was resetting `evaluation` to `null` before each new search. Since `EvalBar` treats `null` as 50% (equal), this caused a snap-to-center flash on every position change before the first depth-4+ result arrived.

Fix: remove the `setEvaluation(null)` — the old value persists until the new search's first info line overwrites it. Smooth transition between positions. On initial mount evaluation is still null so the bar starts at the correct 50/50 neutral.

### 2. Pin eval label to the vertical center of the bar (closes #11)

The eval number was floating at the split point, moving up and down with the eval — distracting and hard to read at a glance.

Fix: pin the label at `top-1/2 -translate-y-1/2` so it stays fixed at the bar's vertical center. The black/white split animates behind it. Text color adapts based on which half covers the center (`topPct > 50` → dark zone → light text).

## Test plan

- [ ] Step through moves → bar transitions smoothly from previous eval to new one, no snap-to-center flash.
- [ ] Eval label ("0.0", "+1.5", "M2") stays fixed in the middle of the bar at all times.
- [ ] Text color flips correctly when the split crosses the center (dark text on light half, light text on dark half).
- [ ] On initial page load (no previous eval), bar starts at 50/50 neutral with "0.0" centered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Updated evaluation bar label positioning to display at a fixed vertical center.
- Modified evaluation state behavior to preserve previous analysis results when switching positions until new analysis begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->