### PR TITLE
feat(social): linked accounts DB migration + CRUD endpoints

### DIFF
--- a/db/migrations/005_linked_accounts.sql
+++ b/db/migrations/005_linked_accounts.sql
@@ -40,12 +40,20 @@ CREATE TABLE IF NOT EXISTS external_games (
     opening_name        TEXT,
 
     CONSTRAINT external_games_platform_game_unique
-        UNIQUE (platform, platform_game_id)
+        UNIQUE (platform, platform_game_id),
+    CONSTRAINT external_games_platform_check
+        CHECK (platform IN ('lichess', 'chesscom')),
+    CONSTRAINT external_games_player_color_check
+        CHECK (player_color IN ('white', 'black')),
+    CONSTRAINT external_games_result_check
+        CHECK (result IS NULL OR result IN ('white', 'black', 'draw'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_external_games_account
     ON external_games (linked_account_id);
 CREATE INDEX IF NOT EXISTS idx_external_games_account_date
     ON external_games (linked_account_id, played_at DESC);
+-- text_pattern_ops enables btree prefix matching for LIKE 'e4 e5%' queries
+-- used by the opening-tree aggregation endpoint.
 CREATE INDEX IF NOT EXISTS idx_external_games_account_opening
-    ON external_games (linked_account_id, opening_moves);
+    ON external_games (linked_account_id, opening_moves text_pattern_ops);

--- a/db/migrations/005_linked_accounts.sql
+++ b/db/migrations/005_linked_accounts.sql
@@ -1,0 +1,51 @@
+-- ── 005_linked_accounts.sql ───────────────────────────────────────────────────
+-- Foundation for chess.com / lichess integration: lets users associate external
+-- platform usernames with their profile, and caches imported games for review
+-- and opening-tree analysis.
+
+-- ── Linked accounts ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS linked_accounts (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    platform        TEXT        NOT NULL,       -- 'lichess' | 'chesscom'
+    username        TEXT        NOT NULL,
+    linked_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_synced_at  TIMESTAMPTZ,
+
+    CONSTRAINT linked_accounts_platform_check
+        CHECK (platform IN ('lichess', 'chesscom')),
+    CONSTRAINT linked_accounts_user_platform_unique
+        UNIQUE (user_id, platform)
+);
+
+CREATE INDEX IF NOT EXISTS idx_linked_accounts_user
+    ON linked_accounts (user_id);
+
+-- ── External games (cached from chess.com / lichess) ─────────────────────────
+CREATE TABLE IF NOT EXISTS external_games (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    linked_account_id   UUID        NOT NULL REFERENCES linked_accounts (id) ON DELETE CASCADE,
+    platform            TEXT        NOT NULL,
+    platform_game_id    TEXT        NOT NULL,
+    white_name          TEXT        NOT NULL,
+    black_name          TEXT        NOT NULL,
+    player_color        TEXT        NOT NULL,       -- 'white' | 'black'
+    result              TEXT,                        -- 'white' | 'black' | 'draw' | null
+    time_control        TEXT,
+    played_at           TIMESTAMPTZ,
+    pgn                 TEXT        NOT NULL,
+    moves_json          JSONB       NOT NULL,        -- [{san, fen}, ...]  pre-parsed
+    opening_moves       TEXT,                        -- space-separated SAN prefix (first 10 half-moves)
+    eco                 TEXT,
+    opening_name        TEXT,
+
+    CONSTRAINT external_games_platform_game_unique
+        UNIQUE (platform, platform_game_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_games_account
+    ON external_games (linked_account_id);
+CREATE INDEX IF NOT EXISTS idx_external_games_account_date
+    ON external_games (linked_account_id, played_at DESC);
+CREATE INDEX IF NOT EXISTS idx_external_games_account_opening
+    ON external_games (linked_account_id, opening_moves);

--- a/db/migrations/005_linked_accounts.sql
+++ b/db/migrations/005_linked_accounts.sql
@@ -15,7 +15,10 @@ CREATE TABLE IF NOT EXISTS linked_accounts (
     CONSTRAINT linked_accounts_platform_check
         CHECK (platform IN ('lichess', 'chesscom')),
     CONSTRAINT linked_accounts_user_platform_unique
-        UNIQUE (user_id, platform)
+        UNIQUE (user_id, platform),
+    -- Needed as a composite FK target for external_games(linked_account_id, platform)
+    CONSTRAINT linked_accounts_id_platform_unique
+        UNIQUE (id, platform)
 );
 
 CREATE INDEX IF NOT EXISTS idx_linked_accounts_user
@@ -24,7 +27,7 @@ CREATE INDEX IF NOT EXISTS idx_linked_accounts_user
 -- ── External games (cached from chess.com / lichess) ─────────────────────────
 CREATE TABLE IF NOT EXISTS external_games (
     id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    linked_account_id   UUID        NOT NULL REFERENCES linked_accounts (id) ON DELETE CASCADE,
+    linked_account_id   UUID        NOT NULL,
     platform            TEXT        NOT NULL,
     platform_game_id    TEXT        NOT NULL,
     white_name          TEXT        NOT NULL,
@@ -41,6 +44,11 @@ CREATE TABLE IF NOT EXISTS external_games (
 
     CONSTRAINT external_games_platform_game_unique
         UNIQUE (platform, platform_game_id),
+    -- Composite FK ensures platform can't disagree with the linked account's platform.
+    CONSTRAINT external_games_account_platform_fk
+        FOREIGN KEY (linked_account_id, platform)
+        REFERENCES linked_accounts (id, platform)
+        ON DELETE CASCADE,
     CONSTRAINT external_games_platform_check
         CHECK (platform IN ('lichess', 'chesscom')),
     CONSTRAINT external_games_player_color_check

--- a/services/social/package.json
+++ b/services/social/package.json
@@ -7,6 +7,7 @@
     "dev": "node --watch src/index.js"
   },
   "dependencies": {
+    "chess.js": "^1.0.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "ioredis": "^5.3.2",

--- a/services/social/src/index.js
+++ b/services/social/src/index.js
@@ -6,6 +6,7 @@ import invitesRouter from './routes/invites.js';
 import historyRouter from './routes/history.js';
 import notificationsRouter from './routes/notifications.js';
 import usersRouter from './routes/users.js';
+import externalRouter from './routes/external.js';
 import { startRatingUpdater } from './ratingUpdater.js';
 
 const app = express();
@@ -23,6 +24,7 @@ app.use('/invites',       requireAuth, invitesRouter);
 app.use('/history',       requireAuth, historyRouter);
 app.use('/notifications', requireAuth, notificationsRouter);
 app.use('/users',         requireAuth, usersRouter);
+app.use('/external',      requireAuth, externalRouter);
 
 // ── 404 ───────────────────────────────────────────────────────────────────────
 app.use((_req, res) => res.status(404).json({ error: 'Not found' }));

--- a/services/social/src/routes/external.js
+++ b/services/social/src/routes/external.js
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import pool from '../db.js';
+
+const router = Router();
+
+const VALID_PLATFORMS = ['lichess', 'chesscom'];
+
+// ── POST /external/link — associate an external platform username ────────────
+router.post('/link', async (req, res) => {
+  const { platform, username } = req.body;
+
+  if (!platform || !username) {
+    return res.status(400).json({ error: 'platform and username are required' });
+  }
+  if (!VALID_PLATFORMS.includes(platform)) {
+    return res.status(400).json({ error: `platform must be one of: ${VALID_PLATFORMS.join(', ')}` });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO linked_accounts (user_id, platform, username)
+       VALUES ($1, $2, $3)
+       RETURNING id, platform, username, linked_at, last_synced_at`,
+      [req.user.id, platform, username.trim()]
+    );
+    return res.status(201).json(rows[0]);
+  } catch (err) {
+    if (err.code === '23505') {
+      return res.status(409).json({ error: `A ${platform} account is already linked` });
+    }
+    console.error('[external] link error:', err.message);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── GET /external/accounts — list linked accounts for the authed user ────────
+router.get('/accounts', async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, platform, username, linked_at, last_synced_at
+       FROM linked_accounts
+       WHERE user_id = $1
+       ORDER BY linked_at`,
+      [req.user.id]
+    );
+    return res.json(rows);
+  } catch (err) {
+    console.error('[external] list accounts error:', err.message);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── DELETE /external/accounts/:id — unlink (cascades to cached games) ────────
+router.delete('/accounts/:id', async (req, res) => {
+  try {
+    const { rowCount } = await pool.query(
+      `DELETE FROM linked_accounts WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.id]
+    );
+    if (rowCount === 0) {
+      return res.status(404).json({ error: 'Linked account not found' });
+    }
+    return res.json({ deleted: true });
+  } catch (err) {
+    console.error('[external] unlink error:', err.message);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/social/src/routes/external.js
+++ b/services/social/src/routes/external.js
@@ -4,12 +4,14 @@ import pool from '../db.js';
 const router = Router();
 
 const VALID_PLATFORMS = ['lichess', 'chesscom'];
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // ── POST /external/link — associate an external platform username ────────────
 router.post('/link', async (req, res) => {
   const { platform, username } = req.body;
+  const trimmedUsername = (username ?? '').trim();
 
-  if (!platform || !username) {
+  if (!platform || !trimmedUsername) {
     return res.status(400).json({ error: 'platform and username are required' });
   }
   if (!VALID_PLATFORMS.includes(platform)) {
@@ -21,7 +23,7 @@ router.post('/link', async (req, res) => {
       `INSERT INTO linked_accounts (user_id, platform, username)
        VALUES ($1, $2, $3)
        RETURNING id, platform, username, linked_at, last_synced_at`,
-      [req.user.id, platform, username.trim()]
+      [req.user.id, platform, trimmedUsername]
     );
     return res.status(201).json(rows[0]);
   } catch (err) {
@@ -52,6 +54,9 @@ router.get('/accounts', async (req, res) => {
 
 // ── DELETE /external/accounts/:id — unlink (cascades to cached games) ────────
 router.delete('/accounts/:id', async (req, res) => {
+  if (!UUID_RE.test(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid account id' });
+  }
   try {
     const { rowCount } = await pool.query(
       `DELETE FROM linked_accounts WHERE id = $1 AND user_id = $2`,


### PR DESCRIPTION
Closes #14

## What

Foundation for the chess.com / lichess integration. Lets users associate external platform usernames with their profile. No game fetching or frontend UI yet — those come in #15 and #16.

## Changes

### Database — `db/migrations/005_linked_accounts.sql`

Two new tables:

**`linked_accounts`**
- `user_id` + `platform` composite unique — each user can link at most one lichess and one chess.com account.
- `CHECK (platform IN ('lichess', 'chesscom'))`.
- `last_synced_at` — updated by the sync endpoint in #15.
- `ON DELETE CASCADE` from `users`.

**`external_games`**
- Caches imported games with pre-parsed `moves_json` (JSONB), `opening_moves` (first 10 half-moves as space-separated SAN, for opening-tree prefix queries in #17), ECO code, and opening name.
- `UNIQUE (platform, platform_game_id)` to deduplicate across syncs.
- Indexed on `linked_account_id` with secondary indexes on `played_at DESC` (game browser) and `opening_moves` (tree drill-down).
- `ON DELETE CASCADE` from `linked_accounts` — unlinking removes all cached games.

### API — `services/social/src/routes/external.js`

Three endpoints, all behind `requireAuth`:

| Method | Path | Description |
|---|---|---|
| `POST` | `/external/link` | Link a platform username. `{ platform, username }`. Returns 409 on duplicate. |
| `GET` | `/external/accounts` | List linked accounts for the authed user. |
| `DELETE` | `/external/accounts/:id` | Unlink. Cascade-deletes cached games. Returns 404 if not found or not owned. |

### Other

- `chess.js ^1.0.0` added to `services/social/package.json` (needed for server-side PGN parsing in #15).
- Route mounted in `services/social/src/index.js` as `/external`.

## Test plan

- [ ] `make migrate` applies cleanly against an existing database.
- [ ] `POST /api/social/external/link` with `{ platform: "lichess", username: "DrNykterstein" }` + valid JWT → 201 with the new row.
- [ ] Duplicate `POST` with the same platform → 409.
- [ ] `GET /api/social/external/accounts` → lists linked accounts for the authed user only.
- [ ] `DELETE /api/social/external/accounts/:id` → 200 + cascade-deletes any future cached games.
- [ ] `DELETE` with someone else's account ID → 404.

## Next in the chain

- #15 — `POST /external/accounts/:id/sync` + game listing endpoints (depends on this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can link and manage their Chess.com and Lichess accounts from their profile (authenticated).
  * The app now imports and caches external games from linked accounts for faster lookup, improved analysis display, and more reliable game history access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->