### PR TITLE
feat(social): opening tree aggregation endpoint

### DIFF
--- a/services/social/src/routes/external.js
+++ b/services/social/src/routes/external.js
@@ -321,26 +321,28 @@ router.get('/accounts/:id/openings', async (req, res) => {
     const account = await getOwnedAccount(req.params.id, req.user.id);
     if (!account) return res.status(404).json({ error: 'Linked account not found' });
 
-    // `moves` query param: space-separated SAN prefix, e.g. "e4 e5 Nf3".
-    // Empty / omitted = root level (first-move stats).
-    const prefix = (req.query.moves ?? '').trim();
+    // Validate and normalize `moves` — could be an array if the query param
+    // is repeated (?moves=e4&moves=e5), and may contain extra whitespace.
+    const rawMoves = req.query.moves;
+    if (rawMoves != null && typeof rawMoves !== 'string') {
+      return res.status(400).json({ error: 'moves must be a space-separated string' });
+    }
+    const prefix = (rawMoves ?? '').trim().replace(/\s+/g, ' ');
     const prefixDepth = prefix ? prefix.split(' ').length : 0;
 
-    // Find all games whose opening_moves start with the prefix, then extract
-    // the next move token after the prefix for grouping.
-    //
-    // opening_moves stores the first 10 half-moves as a space-separated string.
-    // For root level (empty prefix) we match all games and extract the 1st token.
-    // For deeper levels we match "prefix %" and extract the token after the prefix.
-    let queryText;
-    let queryParams;
+    // ── Next-move grouping query ────────────────────────────────────────
+    // Groups games by the next move after the prefix. Leaf-node games
+    // (opening_moves = prefix exactly, no continuation) are excluded from
+    // the grouping (HAVING next_move != '') but included in the totals
+    // via a separate aggregate query below.
+    let groupQuery;
+    let groupParams;
 
     if (!prefix) {
-      // Root level — group by the first move
-      queryText = `
+      groupQuery = `
         SELECT
           split_part(opening_moves, ' ', 1) AS next_move,
-          COUNT(*)::int AS count,
+          COUNT(*) FILTER (WHERE result IS NOT NULL)::int AS count,
           COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
           COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
           COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
@@ -350,58 +352,67 @@ router.get('/accounts/:id/openings', async (req, res) => {
           AND opening_moves != ''
         GROUP BY next_move
         ORDER BY count DESC`;
-      queryParams = [account.id];
+      groupParams = [account.id];
     } else {
-      // Deeper level — match prefix, extract next token
-      // We need games where opening_moves starts with "prefix " (note the trailing space)
-      // or opening_moves equals exactly the prefix (leaf node — no next move).
-      // For grouping, extract token at position (prefixDepth + 1).
-      queryText = `
+      groupQuery = `
         SELECT
           split_part(opening_moves, ' ', $2) AS next_move,
-          COUNT(*)::int AS count,
+          COUNT(*) FILTER (WHERE result IS NOT NULL)::int AS count,
           COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
           COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
           COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
         FROM external_games
         WHERE linked_account_id = $1
-          AND opening_moves LIKE $3
+          AND (opening_moves = $3 OR opening_moves LIKE $4)
         GROUP BY next_move
         HAVING split_part(opening_moves, ' ', $2) != ''
         ORDER BY count DESC`;
-      queryParams = [account.id, prefixDepth + 1, prefix + ' %'];
+      groupParams = [account.id, prefixDepth + 1, prefix, prefix + ' %'];
     }
 
-    const { rows } = await pool.query(queryText, queryParams);
+    const { rows } = await pool.query(groupQuery, groupParams);
 
-    // Compute win rates and totals
-    let totalGames = 0;
-    let totalWins = 0;
-    let totalDraws = 0;
-    let totalLosses = 0;
-    const moves = rows.map((r) => {
-      totalGames += r.count;
-      totalWins += r.wins;
-      totalDraws += r.draws;
-      totalLosses += r.losses;
-      return {
-        move: r.next_move,
-        count: r.count,
-        wins: r.wins,
-        draws: r.draws,
-        losses: r.losses,
-        winRate: r.count > 0 ? Math.round((r.wins / r.count) * 1000) / 1000 : 0,
-      };
-    });
+    // ── Aggregate totals (including leaf-node games) ────────────────────
+    // Count all games matching the prefix (exact OR prefix+continuation)
+    // so leaf nodes at the storage depth limit are included in totalGames.
+    const totalQuery = prefix
+      ? `SELECT
+           COUNT(*) FILTER (WHERE result IS NOT NULL)::int AS total,
+           COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
+           COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
+           COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
+         FROM external_games
+         WHERE linked_account_id = $1
+           AND (opening_moves = $2 OR opening_moves LIKE $3)`
+      : `SELECT
+           COUNT(*) FILTER (WHERE result IS NOT NULL)::int AS total,
+           COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
+           COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
+           COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
+         FROM external_games
+         WHERE linked_account_id = $1
+           AND opening_moves IS NOT NULL
+           AND opening_moves != ''`;
+    const totalParams = prefix ? [account.id, prefix, prefix + ' %'] : [account.id];
+    const { rows: [totals] } = await pool.query(totalQuery, totalParams);
+
+    const moves = rows.map((r) => ({
+      move: r.next_move,
+      count: r.count,
+      wins: r.wins,
+      draws: r.draws,
+      losses: r.losses,
+      winRate: r.count > 0 ? Math.round((r.wins / r.count) * 1000) / 1000 : 0,
+    }));
 
     return res.json({
       prefix: prefix || null,
-      totalGames,
+      totalGames: totals.total,
       stats: {
-        wins: totalWins,
-        draws: totalDraws,
-        losses: totalLosses,
-        winRate: totalGames > 0 ? Math.round((totalWins / totalGames) * 1000) / 1000 : 0,
+        wins: totals.wins,
+        draws: totals.draws,
+        losses: totals.losses,
+        winRate: totals.total > 0 ? Math.round((totals.wins / totals.total) * 1000) / 1000 : 0,
       },
       moves,
     });

--- a/services/social/src/routes/external.js
+++ b/services/social/src/routes/external.js
@@ -328,6 +328,8 @@ router.get('/accounts/:id/openings', async (req, res) => {
       return res.status(400).json({ error: 'moves must be a space-separated string' });
     }
     const prefix = (rawMoves ?? '').trim().replace(/\s+/g, ' ');
+    // Escape LIKE metacharacters so user input can't widen the pattern match.
+    const escapedPrefix = prefix.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
     const prefixDepth = prefix ? prefix.split(' ').length : 0;
 
     // ── Next-move grouping query ────────────────────────────────────────
@@ -363,11 +365,11 @@ router.get('/accounts/:id/openings', async (req, res) => {
           COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
         FROM external_games
         WHERE linked_account_id = $1
-          AND (opening_moves = $3 OR opening_moves LIKE $4)
+          AND (opening_moves = $3 OR opening_moves LIKE $4 ESCAPE '\')
         GROUP BY next_move
         HAVING split_part(opening_moves, ' ', $2) != ''
         ORDER BY count DESC`;
-      groupParams = [account.id, prefixDepth + 1, prefix, prefix + ' %'];
+      groupParams = [account.id, prefixDepth + 1, prefix, escapedPrefix + ' %'];
     }
 
     const { rows } = await pool.query(groupQuery, groupParams);
@@ -383,7 +385,7 @@ router.get('/accounts/:id/openings', async (req, res) => {
            COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
          FROM external_games
          WHERE linked_account_id = $1
-           AND (opening_moves = $2 OR opening_moves LIKE $3)`
+           AND (opening_moves = $2 OR opening_moves LIKE $3 ESCAPE '\')`
       : `SELECT
            COUNT(*) FILTER (WHERE result IS NOT NULL)::int AS total,
            COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
@@ -393,7 +395,7 @@ router.get('/accounts/:id/openings', async (req, res) => {
          WHERE linked_account_id = $1
            AND opening_moves IS NOT NULL
            AND opening_moves != ''`;
-    const totalParams = prefix ? [account.id, prefix, prefix + ' %'] : [account.id];
+    const totalParams = prefix ? [account.id, prefix, escapedPrefix + ' %'] : [account.id];
     const { rows: [totals] } = await pool.query(totalQuery, totalParams);
 
     const moves = rows.map((r) => ({

--- a/services/social/src/routes/external.js
+++ b/services/social/src/routes/external.js
@@ -315,4 +315,100 @@ router.get('/games/:gameId', async (req, res) => {
   }
 });
 
+// ── GET /external/accounts/:id/openings — opening tree aggregation ───────────
+router.get('/accounts/:id/openings', async (req, res) => {
+  try {
+    const account = await getOwnedAccount(req.params.id, req.user.id);
+    if (!account) return res.status(404).json({ error: 'Linked account not found' });
+
+    // `moves` query param: space-separated SAN prefix, e.g. "e4 e5 Nf3".
+    // Empty / omitted = root level (first-move stats).
+    const prefix = (req.query.moves ?? '').trim();
+    const prefixDepth = prefix ? prefix.split(' ').length : 0;
+
+    // Find all games whose opening_moves start with the prefix, then extract
+    // the next move token after the prefix for grouping.
+    //
+    // opening_moves stores the first 10 half-moves as a space-separated string.
+    // For root level (empty prefix) we match all games and extract the 1st token.
+    // For deeper levels we match "prefix %" and extract the token after the prefix.
+    let queryText;
+    let queryParams;
+
+    if (!prefix) {
+      // Root level — group by the first move
+      queryText = `
+        SELECT
+          split_part(opening_moves, ' ', 1) AS next_move,
+          COUNT(*)::int AS count,
+          COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
+          COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
+          COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
+        FROM external_games
+        WHERE linked_account_id = $1
+          AND opening_moves IS NOT NULL
+          AND opening_moves != ''
+        GROUP BY next_move
+        ORDER BY count DESC`;
+      queryParams = [account.id];
+    } else {
+      // Deeper level — match prefix, extract next token
+      // We need games where opening_moves starts with "prefix " (note the trailing space)
+      // or opening_moves equals exactly the prefix (leaf node — no next move).
+      // For grouping, extract token at position (prefixDepth + 1).
+      queryText = `
+        SELECT
+          split_part(opening_moves, ' ', $2) AS next_move,
+          COUNT(*)::int AS count,
+          COUNT(*) FILTER (WHERE result = player_color)::int AS wins,
+          COUNT(*) FILTER (WHERE result = 'draw')::int AS draws,
+          COUNT(*) FILTER (WHERE result IS NOT NULL AND result != 'draw' AND result != player_color)::int AS losses
+        FROM external_games
+        WHERE linked_account_id = $1
+          AND opening_moves LIKE $3
+        GROUP BY next_move
+        HAVING split_part(opening_moves, ' ', $2) != ''
+        ORDER BY count DESC`;
+      queryParams = [account.id, prefixDepth + 1, prefix + ' %'];
+    }
+
+    const { rows } = await pool.query(queryText, queryParams);
+
+    // Compute win rates and totals
+    let totalGames = 0;
+    let totalWins = 0;
+    let totalDraws = 0;
+    let totalLosses = 0;
+    const moves = rows.map((r) => {
+      totalGames += r.count;
+      totalWins += r.wins;
+      totalDraws += r.draws;
+      totalLosses += r.losses;
+      return {
+        move: r.next_move,
+        count: r.count,
+        wins: r.wins,
+        draws: r.draws,
+        losses: r.losses,
+        winRate: r.count > 0 ? Math.round((r.wins / r.count) * 1000) / 1000 : 0,
+      };
+    });
+
+    return res.json({
+      prefix: prefix || null,
+      totalGames,
+      stats: {
+        wins: totalWins,
+        draws: totalDraws,
+        losses: totalLosses,
+        winRate: totalGames > 0 ? Math.round((totalWins / totalGames) * 1000) / 1000 : 0,
+      },
+      moves,
+    });
+  } catch (err) {
+    console.error('[external] openings error:', err.message);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Closes #17

**Stacked on #20** (`feat/external-game-import`) — merge that first.

## What

New endpoint for the opening-tree / repertoire analysis feature. Given a linked account with synced games, returns aggregated move-frequency statistics at any depth of the opening tree.

## Endpoint

`GET /external/accounts/:id/openings`

### Query parameters

| Param | Required | Description |
|---|---|---|
| `moves` | No | Space-separated SAN prefix (e.g. `e4 e5 Nf3`). Omit for root-level (first-move stats). |

### Response

```json
{
  "prefix": "e4 e5",
  "totalGames": 85,
  "stats": { "wins": 40, "draws": 15, "losses": 30, "winRate": 0.471 },
  "moves": [
    { "move": "Nf3", "count": 50, "wins": 25, "draws": 10, "losses": 15, "winRate": 0.5 },
    { "move": "f4",  "count": 12, "wins": 8,  "draws": 1,  "losses": 3,  "winRate": 0.667 }
  ]
}
```

Win rate is from the **linked player's perspective** (`result = player_color`).

### SQL approach

Uses the `opening_moves` text column (first 10 half-moves, space-joined SAN, populated during sync):
- **Root level:** `split_part(opening_moves, ' ', 1)` groups by first move.
- **Deeper levels:** `WHERE opening_moves LIKE 'prefix %'` then `split_part(opening_moves, ' ', depth+1)` extracts the next token.

Drill-down works to the full depth of `opening_moves` (10 half-moves = 5 full moves).

## Test plan

- [ ] `GET /external/accounts/:id/openings` (no `moves`) → returns first-move stats (e.g. `e4: 120, d4: 80`).
- [ ] `GET /external/accounts/:id/openings?moves=e4` → responses to 1.e4.
- [ ] `GET /external/accounts/:id/openings?moves=e4 e5 Nf3 Nc6` → 4 moves deep works.
- [ ] Empty result (no games match prefix) → `{ moves: [], totalGames: 0 }`.
- [ ] Stats `wins + draws + losses = count` for every move row.
- [ ] Another user's account → 404.

## Next

- #16 (frontend: link UI + game browser) — can be done in parallel.
- #18 (frontend: opening tree visualization) — depends on this + #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opening statistics for linked accounts: view aggregated game totals and per-opening win/draw/loss counts with win rates.
  * Optional move-sequence filter to drill into specific opening variations and see suggested next moves with per-move stats.
* **Bug Fixes**
  * Improved input validation for move filters; returns an error for invalid values and more robust handling when an account is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->