### PR TITLE
feat(frontend): opening tree / repertoire visualization

### DIFF
--- a/frontend/src/components/ExternalGames.jsx
+++ b/frontend/src/components/ExternalGames.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { apiFetch } from '../api.js';
+import { OpeningTree } from './OpeningTree.jsx';
 
 export function ExternalGames({ account, token, onViewGame, onBack }) {
+  const [view, setView]       = useState('games'); // 'games' | 'openings'
   const [games, setGames]     = useState([]);
   const [total, setTotal]     = useState(0);
   const [page, setPage]       = useState(1);
@@ -60,6 +62,21 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
           {account.username}'s games
         </h3>
         <span className="font-mono text-xs text-muted">{total} games</span>
+        {/* View toggle */}
+        <div className="ml-auto flex items-center gap-1 bg-surface-high rounded-md p-0.5">
+          {['games', 'openings'].map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={[
+                'font-body text-xs font-semibold px-3 py-1.5 rounded-sm border-0 cursor-pointer transition-all capitalize',
+                view === v ? 'bg-white text-on-surface shadow-sm' : 'bg-transparent text-muted hover:text-on-surface',
+              ].join(' ')}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Error banner */}
@@ -67,12 +84,17 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
         <p className="font-mono text-xs text-danger bg-danger-bg rounded-md px-4 py-2.5">{error}</p>
       )}
 
+      {/* Opening tree view */}
+      {view === 'openings' && (
+        <OpeningTree accountId={account.id} token={token} />
+      )}
+
       {/* Game list */}
-      {loading ? (
+      {view === 'games' && loading ? (
         <p className="font-body text-sm text-muted text-center py-8">Loading games…</p>
-      ) : !error && games.length === 0 ? (
+      ) : view === 'games' && !error && games.length === 0 ? (
         <p className="font-body text-sm text-muted text-center py-8">No games synced yet. Go back and click Sync.</p>
-      ) : (
+      ) : view === 'games' ? (
         <div className="flex flex-col gap-2">
           {games.map((g) => (
             <button
@@ -100,10 +122,10 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
             </button>
           ))}
         </div>
-      )}
+      ) : null}
 
       {/* Pagination */}
-      {totalPages > 1 && (
+      {view === 'games' && totalPages > 1 && (
         <div className="flex items-center justify-center gap-3 py-2">
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}

--- a/frontend/src/components/ExternalGames.jsx
+++ b/frontend/src/components/ExternalGames.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiFetch } from '../api.js';
 import { OpeningTree } from './OpeningTree.jsx';
 
@@ -10,20 +10,24 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
   const [loading, setLoading] = useState(true);
   const [error, setError]     = useState('');
   const limit = 20;
+  const fetchIdRef = useRef(0);
 
   const fetchGames = useCallback(async () => {
+    const id = ++fetchIdRef.current;
     setLoading(true); setError('');
     try {
       const data = await apiFetch(
         `/api/social/external/accounts/${account.id}/games?page=${page}&limit=${limit}`,
         { token }
       );
+      if (id !== fetchIdRef.current) return; // stale response from rapid page change
       setGames(data.games);
       setTotal(data.total);
     } catch (err) {
+      if (id !== fetchIdRef.current) return;
       setError(err.message);
     } finally {
-      setLoading(false);
+      if (id === fetchIdRef.current) setLoading(false);
     }
   }, [account.id, token, page]);
 

--- a/frontend/src/components/OpeningTree.jsx
+++ b/frontend/src/components/OpeningTree.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Chess } from 'chess.js';
 import { Board } from './Board.jsx';
 import { identifyOpening } from '../utils/openings.js';
@@ -8,23 +8,31 @@ export function OpeningTree({ accountId, token }) {
   const [moves, setMoves]       = useState([]);   // current move prefix as array of SAN
   const [data, setData]         = useState(null);  // API response
   const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState('');
+  // Guard against stale responses: rapid drill-down/breadcrumb clicks can
+  // fire multiple requests, and a slow earlier response could overwrite a
+  // newer one. Track the latest request ID and discard anything that doesn't
+  // match.
+  const requestIdRef = useRef(0);
 
   const prefix = moves.join(' ');
 
   const fetchOpenings = useCallback(async () => {
-    setLoading(true);
+    const id = ++requestIdRef.current;
+    setLoading(true); setError('');
     try {
       const params = prefix ? `?moves=${encodeURIComponent(prefix)}` : '';
       const result = await apiFetch(
         `/api/social/external/accounts/${accountId}/openings${params}`,
         { token }
       );
+      if (id !== requestIdRef.current) return; // stale response
       setData(result);
     } catch (err) {
-      console.error('[opening-tree] fetch error:', err.message);
-      setData({ totalGames: 0, stats: { wins: 0, draws: 0, losses: 0, winRate: 0 }, moves: [] });
+      if (id !== requestIdRef.current) return;
+      setError(err.message);
     } finally {
-      setLoading(false);
+      if (id === requestIdRef.current) setLoading(false);
     }
   }, [accountId, token, prefix]);
 
@@ -108,6 +116,8 @@ export function OpeningTree({ accountId, token }) {
         <div className="flex-1 min-w-0">
           {loading ? (
             <p className="font-body text-sm text-muted py-8 text-center">Loading…</p>
+          ) : error ? (
+            <p className="font-mono text-xs text-danger bg-danger-bg rounded-md px-4 py-2.5">{error}</p>
           ) : !data || data.moves.length === 0 ? (
             <p className="font-body text-sm text-muted py-8 text-center">No games at this depth.</p>
           ) : (

--- a/frontend/src/components/OpeningTree.jsx
+++ b/frontend/src/components/OpeningTree.jsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Chess } from 'chess.js';
+import { Board } from './Board.jsx';
+import { identifyOpening } from '../utils/openings.js';
+import { apiFetch } from '../api.js';
+
+export function OpeningTree({ accountId, token }) {
+  const [moves, setMoves]       = useState([]);   // current move prefix as array of SAN
+  const [data, setData]         = useState(null);  // API response
+  const [loading, setLoading]   = useState(true);
+
+  const prefix = moves.join(' ');
+
+  const fetchOpenings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = prefix ? `?moves=${encodeURIComponent(prefix)}` : '';
+      const result = await apiFetch(
+        `/api/social/external/accounts/${accountId}/openings${params}`,
+        { token }
+      );
+      setData(result);
+    } catch (err) {
+      console.error('[opening-tree] fetch error:', err.message);
+      setData({ totalGames: 0, stats: { wins: 0, draws: 0, losses: 0, winRate: 0 }, moves: [] });
+    } finally {
+      setLoading(false);
+    }
+  }, [accountId, token, prefix]);
+
+  useEffect(() => { fetchOpenings(); }, [fetchOpenings]);
+
+  // Compute the current FEN by replaying the prefix moves
+  const currentFen = useMemo(() => {
+    if (moves.length === 0) return 'start';
+    const chess = new Chess();
+    for (const san of moves) {
+      try { chess.move(san); } catch { break; }
+    }
+    return chess.fen();
+  }, [moves]);
+
+  const opening = useMemo(() => identifyOpening(moves), [moves]);
+
+  function drillDown(move) {
+    setMoves((prev) => [...prev, move]);
+  }
+
+  function goToDepth(depth) {
+    setMoves((prev) => prev.slice(0, depth));
+  }
+
+  // Build breadcrumb items: "Root", "1. e4", "1... e5", "2. Nf3", etc.
+  const breadcrumbs = useMemo(() => {
+    const items = [{ label: 'Root', depth: 0 }];
+    for (let i = 0; i < moves.length; i++) {
+      const moveNum = Math.floor(i / 2) + 1;
+      const isWhite = i % 2 === 0;
+      const label = isWhite ? `${moveNum}. ${moves[i]}` : `${moveNum}... ${moves[i]}`;
+      items.push({ label, depth: i + 1 });
+    }
+    return items;
+  }, [moves]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {breadcrumbs.map((bc, i) => (
+          <span key={i} className="flex items-center gap-1.5">
+            {i > 0 && <span className="text-muted text-xs">›</span>}
+            <button
+              onClick={() => goToDepth(bc.depth)}
+              className={[
+                'font-mono text-xs border-0 cursor-pointer transition-colors rounded-sm px-1.5 py-0.5',
+                i === breadcrumbs.length - 1
+                  ? 'bg-primary text-on-primary font-semibold'
+                  : 'bg-transparent text-muted hover:text-on-surface hover:bg-surface-high',
+              ].join(' ')}
+            >
+              {bc.label}
+            </button>
+          </span>
+        ))}
+      </div>
+
+      {/* Opening name */}
+      {opening && (
+        <p className="font-mono text-[0.68rem] text-muted">
+          {opening.eco} · {opening.name}
+        </p>
+      )}
+
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+        {/* Mini board */}
+        <div className="flex-shrink-0">
+          <Board
+            fen={currentFen}
+            playerColour="white"
+            onMove={() => {}}
+            gameOver={true}
+            animated={false}
+            maxWidth={280}
+          />
+        </div>
+
+        {/* Move table */}
+        <div className="flex-1 min-w-0">
+          {loading ? (
+            <p className="font-body text-sm text-muted py-8 text-center">Loading…</p>
+          ) : !data || data.moves.length === 0 ? (
+            <p className="font-body text-sm text-muted py-8 text-center">No games at this depth.</p>
+          ) : (
+            <>
+              {/* Summary */}
+              <div className="flex items-center gap-4 mb-4 font-mono text-xs text-muted">
+                <span>{data.totalGames} games</span>
+                <span className="text-success">{data.stats.wins}W</span>
+                <span>{data.stats.draws}D</span>
+                <span className="text-danger">{data.stats.losses}L</span>
+                <span>({Math.round(data.stats.winRate * 100)}%)</span>
+              </div>
+
+              {/* Rows */}
+              <div className="flex flex-col gap-1">
+                {data.moves.map((m) => {
+                  const total = m.wins + m.draws + m.losses;
+                  const wPct = total > 0 ? (m.wins / total) * 100 : 0;
+                  const dPct = total > 0 ? (m.draws / total) * 100 : 0;
+                  const lPct = total > 0 ? (m.losses / total) * 100 : 0;
+                  return (
+                    <button
+                      key={m.move}
+                      onClick={() => drillDown(m.move)}
+                      className="flex items-center gap-3 p-3 bg-white rounded-md border border-black/[0.04] hover:border-primary/20 hover:shadow-sm transition-all cursor-pointer w-full text-left"
+                    >
+                      {/* Move */}
+                      <span className="font-mono text-sm font-bold text-on-surface w-14 flex-shrink-0">
+                        {m.move}
+                      </span>
+
+                      {/* W/D/L bar */}
+                      <div className="flex-1 h-4 rounded-sm overflow-hidden flex">
+                        <div className="bg-success/70 h-full" style={{ width: `${wPct}%` }} />
+                        <div className="bg-surface-high h-full" style={{ width: `${dPct}%` }} />
+                        <div className="bg-danger/60 h-full" style={{ width: `${lPct}%` }} />
+                      </div>
+
+                      {/* Stats */}
+                      <span className="font-mono text-[0.62rem] text-muted w-12 text-right flex-shrink-0">
+                        {m.count}
+                      </span>
+                      <span className="font-mono text-[0.62rem] font-semibold text-on-surface w-12 text-right flex-shrink-0">
+                        {Math.round(m.winRate * 100)}%
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/social/src/eco.js
+++ b/services/social/src/eco.js
@@ -139,7 +139,7 @@ const ECO = [
   { eco: 'B91', name: 'Sicilian, Najdorf, Zagreb Variation',moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5' },
   { eco: 'B92', name: 'Sicilian, Najdorf, Opocensky Var.',  moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Be2' },
   { eco: 'B94', name: 'Sicilian, Najdorf, 6.Bg5',           moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 Nbd7' },
-  { eco: 'B96', name: 'Sicilian, Najdorf, Poisoned Pawn',   moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4 Qb6' },
+  { eco: 'B96', name: 'Sicilian, Najdorf, Poisoned Pawn',   moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4' },
   { eco: 'B97', name: 'Sicilian, Najdorf, 7...Qb6',         moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4 Qb6' },
 
   // ── Scandinavian ────────────────────────────────────────────────────────
@@ -187,7 +187,7 @@ const ECO = [
   { eco: 'C55', name: 'Two Knights Defence',       moves: 'e4 e5 Nf3 Nc6 Bc4 Nf6' },
   { eco: 'C56', name: 'Two Knights, Max Lange',    moves: 'e4 e5 Nf3 Nc6 Bc4 Nf6 d4 exd4 O-O' },
   { eco: 'C57', name: 'Two Knights, Fried Liver',  moves: 'e4 e5 Nf3 Nc6 Bc4 Nf6 Ng5 d5 exd5 Nxd5 Nxf7' },
-  { eco: 'C58', name: 'Two Knights, 5.g5 d5',      moves: 'e4 e5 Nf3 Nc6 Bc4 Nf6 Ng5 d5 exd5 Na5' },
+  { eco: 'C58', name: 'Two Knights, 4.Ng5 d5',     moves: 'e4 e5 Nf3 Nc6 Bc4 Nf6 Ng5 d5 exd5 Na5' },
 
   // ── Ruy Lopez ──────────────────────────────────────────────────────────
   { eco: 'C60', name: 'Ruy Lopez',                         moves: 'e4 e5 Nf3 Nc6 Bb5' },

--- a/services/social/src/eco.js
+++ b/services/social/src/eco.js
@@ -139,7 +139,7 @@ const ECO = [
   { eco: 'B91', name: 'Sicilian, Najdorf, Zagreb Variation',moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5' },
   { eco: 'B92', name: 'Sicilian, Najdorf, Opocensky Var.',  moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Be2' },
   { eco: 'B94', name: 'Sicilian, Najdorf, 6.Bg5',           moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 Nbd7' },
-  { eco: 'B96', name: 'Sicilian, Najdorf, Poisoned Pawn',   moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4' },
+  { eco: 'B96', name: 'Sicilian, Najdorf, 7.f4',            moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4' },
   { eco: 'B97', name: 'Sicilian, Najdorf, 7...Qb6',         moves: 'e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Bg5 e6 f4 Qb6' },
 
   // ── Scandinavian ────────────────────────────────────────────────────────

--- a/services/social/src/eco.js
+++ b/services/social/src/eco.js
@@ -32,7 +32,7 @@ const ECO = [
   { eco: 'A45', name: 'Trompowsky Attack',   moves: 'd4 Nf6 Bg5' },
   { eco: 'A80', name: 'Dutch Defence',       moves: 'd4 f5' },
   { eco: 'A84', name: 'Dutch Defence',       moves: 'd4 f5 c4' },
-  { eco: 'A00', name: "Queen's Pawn Game",   moves: 'd4 d5' },
+  { eco: 'D00', name: "Queen's Pawn Game",   moves: 'd4 d5' },
 
   // ── Queen's Gambit ─────────────────────────────────────────────────────
   { eco: 'D06', name: "Queen's Gambit",                      moves: 'd4 d5 c4' },


### PR DESCRIPTION
Closes #18

**Stacked on #22** (`feat/external-accounts-ui`) — merge that first.

## What

The final piece of the chess.com / lichess integration: an interactive opening tree that shows what openings a linked player uses, with drill-down by move, win/draw/loss stats, and a mini board.

## New component: `OpeningTree.jsx`

- **Breadcrumb trail**: `Root › 1. e4 › 1... e5 › 2. Nf3`. Click any breadcrumb to navigate back.
- **Mini board** (280px): shows the current position by replaying the prefix moves via chess.js.
- **ECO opening name**: displayed when the prefix matches a known opening (reuses `identifyOpening` from `utils/openings.js`).
- **Move table**: one row per candidate next-move at the current depth:
  - Move (SAN, bold)
  - Stacked W/D/L bar (green / gray / red, proportional)
  - Game count
  - Win rate %
  - Click to drill down (appends move to prefix, re-fetches).
- **Summary stats** above the table: total games, W/D/L counts, aggregate win rate.
- **Empty state** when no games match the current prefix.

## Integration

Toggle added to `ExternalGames.jsx` header: **Games** / **Openings** pill switcher. When "Openings" is active, the game list and pagination hide, and `OpeningTree` renders in their place with the selected account's ID.

## Test plan

- [ ] Select a linked account with synced games → click "Openings" toggle → first-move stats load.
- [ ] Click a move (e.g. "e4") → drills down, shows responses with updated stats.
- [ ] Breadcrumb trail shows full move sequence; clicking "Root" returns to top.
- [ ] Mini board shows correct position at every depth.
- [ ] ECO name appears when line matches (e.g. "B20 · Sicilian Defence" after 1. e4 c5).
- [ ] W/D/L bars render proportionally; percentages are correct.
- [ ] Toggle back to "Games" → game list reappears.
- [ ] Deep drill-down (5+ moves) works to the stored depth limit (10 half-moves).
- [ ] Empty prefix at a deep level shows "No games at this depth" gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive "Openings" view with board preview, breadcrumb navigation, and move exploration; toggle between games list and openings.

* **Improvements**
  * More reliable loading and pagination when rapidly switching pages or views; UI avoids showing stale results.

* **Bug Fixes**
  * Updated opening labels/codes so displayed opening names and classifications are more accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->