### PR TITLE
chore(deploy): apply DB migrations automatically on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
 
+# Only one deploy at a time. Queued runs wait for the running one to finish
+# (don't cancel) so no commit's deploy gets silently dropped. This also
+# prevents two migration runs from racing on the same database.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy to VPS
@@ -33,12 +40,19 @@ jobs:
             echo "→ Waiting for postgres to be ready"
             # Postgres is depended on by the other services, but we need it
             # reachable before running migrate. Wait for pg_isready up to ~30s.
+            pg_ready=0
             for i in 1 2 3 4 5 6 7 8 9 10; do
               if docker compose exec -T postgres pg_isready -U chess -d chess >/dev/null 2>&1; then
+                pg_ready=1
                 break
               fi
               sleep 3
             done
+            if [ "$pg_ready" != "1" ]; then
+              echo "✗ postgres did not become ready within 30s — aborting deploy"
+              docker compose logs postgres --tail=50
+              exit 1
+            fi
 
             echo "→ Applying database migrations"
             make migrate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,13 @@ jobs:
             echo "→ Rebuilding images"
             docker compose build --no-cache
 
-            echo "→ Restarting services"
+            echo "→ Stopping services"
             docker compose down
-            docker compose up -d
+
+            echo "→ Starting postgres + redis first (for migrations)"
+            docker compose up -d postgres redis
 
             echo "→ Waiting for postgres to be ready"
-            # Postgres is depended on by the other services, but we need it
-            # reachable before running migrate. Wait for pg_isready up to ~30s.
             pg_ready=0
             for i in 1 2 3 4 5 6 7 8 9 10; do
               if docker compose exec -T postgres pg_isready -U chess -d chess >/dev/null 2>&1; then
@@ -56,6 +56,9 @@ jobs:
 
             echo "→ Applying database migrations"
             make migrate
+
+            echo "→ Starting all services"
+            docker compose up -d
 
             echo "→ Waiting for health checks"
             sleep 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,19 @@ jobs:
             docker compose down
             docker compose up -d
 
+            echo "→ Waiting for postgres to be ready"
+            # Postgres is depended on by the other services, but we need it
+            # reachable before running migrate. Wait for pg_isready up to ~30s.
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if docker compose exec -T postgres pg_isready -U chess -d chess >/dev/null 2>&1; then
+                break
+              fi
+              sleep 3
+            done
+
+            echo "→ Applying database migrations"
+            make migrate
+
             echo "→ Waiting for health checks"
             sleep 10
             docker compose ps

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,12 @@ ps:
 # ── Database ──────────────────────────────────────────────────────────────────
 
 ## Apply any pending migrations. Idempotent — tracks applied files in the
-## `_migrations` table, so it's safe to run on every deploy.
+## `_migrations` table, so it's safe to run on every deploy. flock prevents
+## concurrent runs on the same host (e.g. a manual `make migrate` kicking off
+## while the deploy workflow is also running). The GitHub Actions
+## `concurrency: deploy` group serialises deploys themselves.
 migrate:
-	@./db/migrate.sh
+	@flock /tmp/chess-with-friends.migrate.lock ./db/migrate.sh
 
 # ── Frontend dev server ───────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,10 @@ ps:
 
 # ── Database ──────────────────────────────────────────────────────────────────
 
-## Apply all migrations in order
+## Apply any pending migrations. Idempotent — tracks applied files in the
+## `_migrations` table, so it's safe to run on every deploy.
 migrate:
-	@for f in db/migrations/*.sql; do \
-		echo "→ applying $$f"; \
-		docker compose exec -T postgres psql -U chess -d chess -f /docker-entrypoint-initdb.d/$$(basename $$f); \
-	done
+	@./db/migrate.sh
 
 # ── Frontend dev server ───────────────────────────────────────────────────────
 

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Apply any db/migrations/*.sql files that haven't already been recorded in
+# the `_migrations` tracking table. Idempotent: already-applied files are
+# skipped, so it's safe to run on every deploy.
+#
+# On the first run against an existing database, detects which of the
+# historical migrations 001–004 have already been applied (based on the
+# schema artifacts they create) and pre-seeds the tracking table so they
+# aren't re-run.
+#
+# Designed to be run from the repo root, against the `postgres` container
+# defined in docker-compose.yml. Example:
+#
+#     ./db/migrate.sh
+#
+set -euo pipefail
+
+PSQL="docker compose exec -T postgres psql -U chess -d chess"
+
+# ── 1. Tracking table + bootstrap for existing databases ─────────────────────
+# Every branch below is idempotent: re-running the whole bootstrap costs
+# nothing and won't duplicate rows (ON CONFLICT DO NOTHING).
+$PSQL -v ON_ERROR_STOP=1 <<'SQL'
+CREATE TABLE IF NOT EXISTS _migrations (
+    filename   TEXT        PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Pre-seed historical migrations based on their distinguishing artifacts.
+-- This only matters on the first run against a database that was
+-- initialized before tracking existed — subsequent runs are no-ops.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'users') THEN
+        INSERT INTO _migrations (filename) VALUES ('001_init.sql')
+        ON CONFLICT DO NOTHING;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_schema = 'public'
+                 AND table_name = 'invites'
+                 AND column_name = 'addressee_id') THEN
+        INSERT INTO _migrations (filename) VALUES ('002_invites_addressee.sql')
+        ON CONFLICT DO NOTHING;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'rating_history') THEN
+        INSERT INTO _migrations (filename) VALUES ('003_rating_history.sql')
+        ON CONFLICT DO NOTHING;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_schema = 'public'
+                 AND table_name = 'ratings'
+                 AND column_name = 'game_type') THEN
+        INSERT INTO _migrations (filename) VALUES ('004_ratings_per_type.sql')
+        ON CONFLICT DO NOTHING;
+    END IF;
+END $$;
+SQL
+
+# ── 2. Apply any migration not yet in the tracking table ─────────────────────
+for f in db/migrations/*.sql; do
+    name=$(basename "$f")
+    applied=$($PSQL -tAc "SELECT 1 FROM _migrations WHERE filename = '$name'" | tr -d '[:space:]')
+    if [ -n "$applied" ]; then
+        echo "✓ $name (already applied)"
+        continue
+    fi
+
+    echo "→ applying $name"
+    $PSQL -v ON_ERROR_STOP=1 -f "/docker-entrypoint-initdb.d/$name"
+    $PSQL -v ON_ERROR_STOP=1 -c "INSERT INTO _migrations (filename) VALUES ('$name')"
+done
+
+echo "✓ migrations up to date"


### PR DESCRIPTION
Closes #24

## Problem

The postgres image only runs `db/migrations/*.sql` on **first boot** via the `docker-entrypoint-initdb.d/` mechanism. Any migration added after the database was initialized never runs without a manual `make migrate` over SSH — which is exactly how the production "Linked" page ended up 500'ing after PR #19 and PR #22 merged. Migrations `005` and `006` never ran on the VPS, so `linked_accounts` and `external_games` don't exist and every query against them throws `relation does not exist`.

## What this PR does

Three coordinated changes:

### 1. `db/migrate.sh` — tracked migration runner

A small bash script that:
- Ensures a `_migrations` tracking table exists (`filename TEXT PRIMARY KEY, applied_at TIMESTAMPTZ`).
- **Bootstraps existing databases** on first run: detects historical migrations 001–004 via their distinguishing schema artifacts (users table, `invites.addressee_id` column, `rating_history` table, `ratings.game_type` column) and pre-seeds the tracking table so they aren't re-run and fail.
- Loops over `db/migrations/*.sql`; for each file not yet in `_migrations`, runs it with `ON_ERROR_STOP=1` and records the filename on success.
- Idempotent — re-running on an up-to-date database is a no-op.

### 2. `Makefile`

`make migrate` now calls `./db/migrate.sh` instead of the old blind-replay loop.

### 3. `.github/workflows/deploy.yml`

Adds two new steps after `docker compose up -d` and before the final health check:
- A `pg_isready` retry loop (up to ~30s) so the migration step doesn't race container startup.
- `make migrate` to apply any pending migrations on every deploy.

## Why no tracking table in postgres image itself?

Could have used an init-container / sidecar with a migration tool (Flyway, Liquibase, etc.), but this is a small project and a 50-line bash script is way simpler to reason about and audit. Can revisit if the schema gets complex.

## Test plan

- [ ] After merging, the next push to `main` triggers a deploy that runs `make migrate` automatically.
- [ ] Deploy log shows "applying 005_linked_accounts.sql" and "applying 006_external_games_per_account_unique.sql" the first time (since they're not yet in `_migrations` on prod).
- [ ] Subsequent deploys show "(already applied)" for all migrations and exit cleanly.
- [ ] `/api/social/external/accounts` stops returning 500 — the "Linked" page loads.
- [ ] Linking a lichess or chess.com account succeeds.
- [ ] Running `./db/migrate.sh` locally against a fresh `make up` database works (bootstrap detects nothing, applies all migrations in order).
- [ ] Running `./db/migrate.sh` a second time immediately shows every migration as "(already applied)" and exits cleanly.

## Out of scope

- Proper migration rollback / `down` scripts. Forward-only is fine for this project.
- Concurrent-safety locks. Deploys are serialized via SSH + GitHub Actions concurrency; race isn't realistic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now ensures only one deploy runs at a time and queues others; waits for database readiness before proceeding to migrations and service start.
  * Migrations hardened: introduced idempotent, tracked migration application with a lock to prevent concurrent runs and ensure pending migrations are applied before health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->