### PR TITLE
feat(infra): automated daily Postgres backups to S3/B2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ S3_ENDPOINT=
 # Daily pg_dump → s3://$S3_BUCKET/backups/ via the `db-backup` service.
 # Backups older than BACKUP_KEEP_DAYS are pruned after each successful upload.
 # Schedule is a standard crontab expression in UTC.
-BACKUP_SCHEDULE=0 3 * * *
+BACKUP_SCHEDULE="0 3 * * *"
 BACKUP_KEEP_DAYS=14
 # Set to 1 to also run a backup immediately when the container starts
 # (useful when testing on a fresh deploy).

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,13 @@ S3_SECRET_KEY=
 # Leave blank for AWS; set for B2 or other S3-compatible providers, e.g.:
 # S3_ENDPOINT=https://s3.us-west-004.backblazeb2.com
 S3_ENDPOINT=
+
+# ── Database backups ──────────────────────────────────────────────────────────
+# Daily pg_dump → s3://$S3_BUCKET/backups/ via the `db-backup` service.
+# Backups older than BACKUP_KEEP_DAYS are pruned after each successful upload.
+# Schedule is a standard crontab expression in UTC.
+BACKUP_SCHEDULE=0 3 * * *
+BACKUP_KEEP_DAYS=14
+# Set to 1 to also run a backup immediately when the container starts
+# (useful when testing on a fresh deploy).
+BACKUP_RUN_ON_STARTUP=0

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ migrate:
 		docker compose exec -T postgres psql -U chess -d chess -f /docker-entrypoint-initdb.d/$$(basename $$f); \
 	done
 
+## Run a database backup immediately (doesn't wait for the next cron tick)
+backup-now:
+	docker compose exec db-backup /app/backup.sh
+
+## List recent backups in the S3 bucket
+backup-list:
+	docker compose exec db-backup sh -c 'AWS_ACCESS_KEY_ID="$$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$$S3_SECRET_KEY" AWS_DEFAULT_REGION="$$S3_REGION" aws s3 ls $${S3_ENDPOINT:+--endpoint-url=$$S3_ENDPOINT} "s3://$$S3_BUCKET/backups/" | sort'
+
 # ── Frontend dev server ───────────────────────────────────────────────────────
 
 ## Start the Vite dev server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,23 @@ services:
       timeout: 5s
       retries: 5
 
+  db-backup:
+    build: ./services/db-backup
+    env_file: .env
+    environment:
+      PGHOST: postgres
+      PGUSER: chess
+      PGDATABASE: chess
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      # Daily at 03:00 UTC. Override in .env with BACKUP_SCHEDULE if needed.
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 3 * * *}
+      BACKUP_KEEP_DAYS: ${BACKUP_KEEP_DAYS:-14}
+      BACKUP_RUN_ON_STARTUP: ${BACKUP_RUN_ON_STARTUP:-0}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   redis_data:

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -26,6 +26,11 @@ All controlled via `.env` (see `.env.example`):
 - **See recent backups**: `make backup-list`
 - **Run one now**: `make backup-now`
 - **Tail logs**: `make logs svc=db-backup`
+- **Monthly restore drill** — once a month, download the latest backup
+  to a staging environment, restore it, and verify row counts / API
+  sanity. This catches silent backup corruption before it matters.
+  A calendar reminder is the simplest trigger until we add Sentry
+  cron check-ins (#27).
 
 ## Restoring from a backup
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,116 @@
+# Database backups & restore
+
+## What gets backed up
+
+The `db-backup` service (`services/db-backup/`) runs a daily `pg_dump` of the
+whole `chess` database, gzips it, uploads it to
+`s3://$S3_BUCKET/backups/chess-<UTC-timestamp>.sql.gz`, and prunes backups
+older than `$BACKUP_KEEP_DAYS` (default 14 days).
+
+The dump uses `--clean --if-exists`, so restoring it drops the existing
+schema first — perfect for a clean recovery, destructive on a running DB.
+
+## Configuration
+
+All controlled via `.env` (see `.env.example`):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `S3_BUCKET`, `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_ENDPOINT` | — | Target storage. `S3_ENDPOINT` is only set for B2 / other S3-compatible providers. |
+| `BACKUP_SCHEDULE` | `0 3 * * *` | Cron expression (UTC). Default is 03:00 UTC daily. |
+| `BACKUP_KEEP_DAYS` | `14` | Age cutoff for pruning. |
+| `BACKUP_RUN_ON_STARTUP` | `0` | Set to `1` to run a backup immediately on container start (useful when testing). |
+
+## Day-to-day
+
+- **See recent backups**: `make backup-list`
+- **Run one now**: `make backup-now`
+- **Tail logs**: `make logs svc=db-backup`
+
+## Restoring from a backup
+
+This is destructive — it drops every table in the current database and
+recreates them from the dump. **Always test in a staging environment
+first.** On the live VPS, take a fresh manual backup before starting
+(`make backup-now`) so you can get back to the current state if the
+restore goes sideways.
+
+### Step 1 — pick a backup
+
+```bash
+make backup-list
+# 2026-04-11 03:00:00    12345  backups/chess-2026-04-11T03-00-00Z.sql.gz
+# 2026-04-10 03:00:00    12123  backups/chess-2026-04-10T03-00-00Z.sql.gz
+```
+
+### Step 2 — download it locally
+
+```bash
+# From the repo root, inside the db-backup container:
+docker compose exec -T db-backup sh -c '
+  AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" \
+  AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" \
+  AWS_DEFAULT_REGION="$S3_REGION" \
+  aws s3 cp ${S3_ENDPOINT:+--endpoint-url=$S3_ENDPOINT} \
+    s3://$S3_BUCKET/backups/chess-2026-04-11T03-00-00Z.sql.gz -
+' > /tmp/chess-restore.sql.gz
+```
+
+### Step 3 — stop app services (keep postgres running)
+
+```bash
+docker compose stop api game social
+```
+
+This prevents in-flight writes from interfering with the restore.
+
+### Step 4 — pipe the dump into psql
+
+```bash
+gunzip -c /tmp/chess-restore.sql.gz | \
+  docker compose exec -T postgres psql -U chess -d chess
+```
+
+`psql` will print errors as it drops / recreates tables — that's expected.
+Look for the final exit status; if `psql` returns 0, the restore succeeded.
+
+### Step 5 — start app services again
+
+```bash
+docker compose start api game social
+```
+
+### Step 6 — verify
+
+- Hit `/api/social/history` for a known user and confirm the games list
+  matches what you expect at the backup timestamp.
+- Check `/api/social/friends` for a test user.
+- `docker compose logs --tail=20 api game social` for any lingering errors.
+
+## Disaster recovery from scratch
+
+If the VPS itself is gone (new machine):
+
+1. Provision a new VPS, install Docker, clone the repo, set `.env` with the
+   same S3 credentials as the lost machine.
+2. `docker compose up -d` — empty database boots.
+3. Follow the restore procedure above with the latest S3 backup.
+4. Point DNS at the new VPS.
+
+## Troubleshooting
+
+**"relation X already exists" during restore.** The dump uses `--clean
+--if-exists`, which drops before creating, so this shouldn't happen unless
+someone restored into a partially-initialised database. If it does, drop
+the schema by hand first: `DROP SCHEMA public CASCADE; CREATE SCHEMA public;`
+and re-run the restore.
+
+**Backups not uploading.** Check `make logs svc=db-backup`. Most likely
+causes: wrong S3 credentials, wrong endpoint URL for B2, or postgres not
+reachable (should never happen because the service has
+`depends_on: { postgres: { condition: service_healthy } }`).
+
+**Postgres client / server version mismatch.** The `db-backup` Dockerfile
+pins `postgresql16-client` to match `postgres:16-alpine` from the main
+compose file. If you bump the postgres image to 17+, update the Dockerfile
+to match — `pg_dump` requires a client `>=` the server version.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -112,8 +112,9 @@ and re-run the restore.
 
 **Backups not uploading.** Check `make logs svc=db-backup`. Most likely
 causes: wrong S3 credentials, wrong endpoint URL for B2, or postgres not
-reachable (should never happen because the service has
-`depends_on: { postgres: { condition: service_healthy } }`).
+reachable. Note that `depends_on: service_healthy` only gates initial
+container startup — if postgres becomes unavailable later, the backup
+script will fail until it recovers.
 
 **Postgres client / server version mismatch.** The `db-backup` Dockerfile
 pins `postgresql16-client` to match `postgres:16-alpine` from the main

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -51,7 +51,7 @@ docker compose exec -T db-backup sh -c '
   AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" \
   AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" \
   AWS_DEFAULT_REGION="$S3_REGION" \
-  aws s3 cp ${S3_ENDPOINT:+--endpoint-url=$S3_ENDPOINT} \
+  aws s3 cp ${S3_ENDPOINT:+"--endpoint-url=$S3_ENDPOINT"} \
     s3://$S3_BUCKET/backups/chess-2026-04-11T03-00-00Z.sql.gz -
 ' > /tmp/chess-restore.sql.gz
 ```

--- a/services/db-backup/Dockerfile
+++ b/services/db-backup/Dockerfile
@@ -1,0 +1,22 @@
+# ── Chess-with-friends database backup container ──────────────────────────────
+# Runs pg_dump + gzip + aws s3 cp on a cron schedule, then prunes old backups.
+# Keeps postgres-client pinned to the same major version as the postgres service
+# (16) because pg_dump requires a client >= server version.
+
+FROM alpine:3.19
+
+RUN apk add --no-cache \
+        bash \
+        postgresql16-client \
+        aws-cli \
+        tzdata \
+        coreutils
+
+WORKDIR /app
+
+COPY backup.sh entrypoint.sh ./
+RUN chmod +x backup.sh entrypoint.sh
+
+# Crond is busybox in alpine — read from /var/spool/cron/crontabs/root.
+# The entrypoint writes the schedule there at startup.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/services/db-backup/backup.sh
+++ b/services/db-backup/backup.sh
@@ -54,7 +54,7 @@ rm -f "$DUMP_FILE"
 # cross-filesystem-safe). We reconstruct the real ISO timestamp and compare to
 # a cutoff epoch.
 CUTOFF_EPOCH=$(date -u -d "${KEEP_DAYS} days ago" +%s)
-echo "[backup] pruning backups older than ${KEEP_DAYS} days (< $(date -u -d @${CUTOFF_EPOCH} +%FT%TZ))"
+echo "[backup] pruning backups older than ${KEEP_DAYS} days (< $(date -u -d "@${CUTOFF_EPOCH}" +%FT%TZ))"
 
 aws s3 ls "${ENDPOINT_ARG[@]}" "s3://${S3_BUCKET}/backups/" | while read -r LINE; do
     KEY=$(echo "$LINE" | awk '{print $4}')

--- a/services/db-backup/backup.sh
+++ b/services/db-backup/backup.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Dump the chess database, gzip it, upload to S3/B2, then prune backups older
+# than ${BACKUP_KEEP_DAYS} (default: 14 days).
+#
+# Expects the following env vars (provided via docker-compose env_file / environment):
+#   PGHOST, PGUSER, PGDATABASE, PGPASSWORD  — Postgres connection
+#   S3_BUCKET, S3_REGION                    — target bucket
+#   S3_ACCESS_KEY, S3_SECRET_KEY            — credentials (mapped to AWS_* below)
+#   S3_ENDPOINT                             — optional, for B2 / other S3-compatible
+#   BACKUP_KEEP_DAYS                        — optional, default 14
+#
+set -euo pipefail
+
+KEEP_DAYS="${BACKUP_KEEP_DAYS:-14}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+DUMP_FILE="/tmp/chess-${TIMESTAMP}.sql.gz"
+S3_KEY="backups/chess-${TIMESTAMP}.sql.gz"
+
+# ── aws-cli env (no IAM roles here, just static creds) ────────────────────────
+export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
+export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
+export AWS_DEFAULT_REGION="${S3_REGION}"
+
+ENDPOINT_ARG=()
+if [ -n "${S3_ENDPOINT:-}" ]; then
+    ENDPOINT_ARG=(--endpoint-url="${S3_ENDPOINT}")
+fi
+
+# ── Dump ──────────────────────────────────────────────────────────────────────
+echo "[backup] $(date -u +%FT%TZ) starting pg_dump"
+
+pg_dump \
+    --host="$PGHOST" \
+    --username="$PGUSER" \
+    --dbname="$PGDATABASE" \
+    --no-owner \
+    --no-privileges \
+    --clean \
+    --if-exists \
+    --format=plain \
+    | gzip -9 > "$DUMP_FILE"
+
+SIZE=$(du -h "$DUMP_FILE" | cut -f1)
+echo "[backup] dumped ${SIZE} — uploading to s3://${S3_BUCKET}/${S3_KEY}"
+
+# ── Upload ────────────────────────────────────────────────────────────────────
+aws s3 cp "${ENDPOINT_ARG[@]}" "$DUMP_FILE" "s3://${S3_BUCKET}/${S3_KEY}"
+rm -f "$DUMP_FILE"
+
+# ── Prune backups older than KEEP_DAYS ────────────────────────────────────────
+# Filename format: chess-YYYY-MM-DDTHH-MM-SSZ.sql.gz  (the T delimiter and the
+# hyphen-separated time are ISO-8601 with colons replaced so the filename is
+# cross-filesystem-safe). We reconstruct the real ISO timestamp and compare to
+# a cutoff epoch.
+CUTOFF_EPOCH=$(date -u -d "${KEEP_DAYS} days ago" +%s)
+echo "[backup] pruning backups older than ${KEEP_DAYS} days (< $(date -u -d @${CUTOFF_EPOCH} +%FT%TZ))"
+
+aws s3 ls "${ENDPOINT_ARG[@]}" "s3://${S3_BUCKET}/backups/" | while read -r LINE; do
+    KEY=$(echo "$LINE" | awk '{print $4}')
+    [ -z "$KEY" ] && continue
+
+    # Extract "2026-04-11T19-00-00Z" from "chess-2026-04-11T19-00-00Z.sql.gz"
+    TS=$(echo "$KEY" | sed -n 's/^chess-\(.*\)\.sql\.gz$/\1/p')
+    [ -z "$TS" ] && continue
+
+    # Convert to proper ISO by replacing hyphens in the time portion with colons
+    ISO=$(echo "$TS" | sed 's/T\([0-9]\{2\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\)Z/T\1:\2:\3Z/')
+    FILE_EPOCH=$(date -u -d "$ISO" +%s 2>/dev/null || echo 0)
+    [ "$FILE_EPOCH" -eq 0 ] && continue
+
+    if [ "$FILE_EPOCH" -lt "$CUTOFF_EPOCH" ]; then
+        echo "[backup] deleting old backup: $KEY"
+        aws s3 rm "${ENDPOINT_ARG[@]}" "s3://${S3_BUCKET}/backups/${KEY}"
+    fi
+done
+
+echo "[backup] $(date -u +%FT%TZ) done"

--- a/services/db-backup/entrypoint.sh
+++ b/services/db-backup/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Container entrypoint: installs the cron schedule, optionally runs a backup
+# immediately, then runs crond in the foreground so the container stays up.
+#
+set -euo pipefail
+
+SCHEDULE="${BACKUP_SCHEDULE:-0 3 * * *}"  # default: daily at 03:00 UTC
+LOG_FILE="/var/log/backup.log"
+
+echo "[entrypoint] scheduling backups: ${SCHEDULE}"
+
+# Busybox crond in alpine reads /var/spool/cron/crontabs/root
+mkdir -p /var/spool/cron/crontabs
+# Env vars aren't inherited into cron jobs — write them into the crontab
+# directly so the backup script sees them.
+{
+    env | grep -E '^(PG|S3_|BACKUP_)' | sed 's/^/export /'
+    echo ""
+    echo "${SCHEDULE} . /etc/profile.d/env.sh; /app/backup.sh >> ${LOG_FILE} 2>&1"
+} > /tmp/crontab
+
+# Move env exports to a profile script the cron job can source
+mkdir -p /etc/profile.d
+grep '^export ' /tmp/crontab > /etc/profile.d/env.sh
+grep -v '^export ' /tmp/crontab > /var/spool/cron/crontabs/root
+
+touch "$LOG_FILE"
+
+if [ "${BACKUP_RUN_ON_STARTUP:-0}" = "1" ]; then
+    echo "[entrypoint] running backup once at startup (BACKUP_RUN_ON_STARTUP=1)"
+    /app/backup.sh || echo "[entrypoint] startup backup failed — crond will still start"
+fi
+
+echo "[entrypoint] starting crond"
+crond -f -l 8 &
+CROND_PID=$!
+
+# Tail the log so `docker logs db-backup` shows backup output
+tail -F "$LOG_FILE" &
+TAIL_PID=$!
+
+# Forward signals to crond for clean shutdown
+trap "kill -TERM $CROND_PID $TAIL_PID 2>/dev/null; exit 0" TERM INT
+wait $CROND_PID

--- a/services/db-backup/entrypoint.sh
+++ b/services/db-backup/entrypoint.sh
@@ -44,5 +44,6 @@ tail -F "$LOG_FILE" &
 TAIL_PID=$!
 
 # Forward signals to crond for clean shutdown
-trap "kill -TERM $CROND_PID $TAIL_PID 2>/dev/null; exit 0" TERM INT
+cleanup() { kill -TERM "$CROND_PID" "$TAIL_PID" 2>/dev/null; exit 0; }
+trap cleanup TERM INT
 wait $CROND_PID

--- a/services/db-backup/entrypoint.sh
+++ b/services/db-backup/entrypoint.sh
@@ -25,6 +25,7 @@ mkdir -p /var/spool/cron/crontabs
 # (e.g. misconfigured compose with no PG/S3/BACKUP vars).
 mkdir -p /etc/profile.d
 grep '^export ' /tmp/crontab > /etc/profile.d/env.sh || true
+chmod 600 /etc/profile.d/env.sh  # contains S3 credentials
 grep -v '^export ' /tmp/crontab > /var/spool/cron/crontabs/root
 
 touch "$LOG_FILE"

--- a/services/db-backup/entrypoint.sh
+++ b/services/db-backup/entrypoint.sh
@@ -20,9 +20,11 @@ mkdir -p /var/spool/cron/crontabs
     echo "${SCHEDULE} . /etc/profile.d/env.sh; /app/backup.sh >> ${LOG_FILE} 2>&1"
 } > /tmp/crontab
 
-# Move env exports to a profile script the cron job can source
+# Move env exports to a profile script the cron job can source.
+# `|| true` prevents set -e from aborting if no matching lines exist
+# (e.g. misconfigured compose with no PG/S3/BACKUP vars).
 mkdir -p /etc/profile.d
-grep '^export ' /tmp/crontab > /etc/profile.d/env.sh
+grep '^export ' /tmp/crontab > /etc/profile.d/env.sh || true
 grep -v '^export ' /tmp/crontab > /var/spool/cron/crontabs/root
 
 touch "$LOG_FILE"


### PR DESCRIPTION
Closes #26

## Why

The production database holds every user, game, rating, history row, and now external-account cache — and has **zero backup strategy**. A botched migration, VPS disk failure, or `DROP DATABASE` typo would mean starting from scratch. This is the highest-priority issue in the tracker for good reason.

## What

A new `db-backup` service that runs `pg_dump → gzip → S3` on a nightly cron and prunes backups older than a configurable retention window.

### Architecture

- **`services/db-backup/`** — new thin alpine-based image:
  - `postgresql16-client` pinned to match the postgres server major version (`pg_dump` requires client ≥ server)
  - `aws-cli` for S3 upload (works with AWS, B2, and other S3-compatible providers via `S3_ENDPOINT`)
  - `busybox crond` for scheduling
- **`docker-compose.yml`** — new `db-backup` service wired into `.env` for Postgres + S3 creds. `depends_on: postgres: service_healthy` so it waits for the DB.
- **`entrypoint.sh`** — installs the cron schedule, optionally runs a backup immediately (`BACKUP_RUN_ON_STARTUP=1`), and tails the log so `docker compose logs db-backup` shows backup output.
- **`backup.sh`** — dumps, uploads, then prunes by parsing the ISO timestamp out of each S3 key and comparing to a cutoff epoch.

### Configuration (all via `.env`, already plumbed through)

| Var | Default | Purpose |
|---|---|---|
| `S3_BUCKET`, `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_ENDPOINT` | — | Target storage (already existed; now also consumed by this service) |
| `BACKUP_SCHEDULE` | `0 3 * * *` | UTC cron expression |
| `BACKUP_KEEP_DAYS` | `14` | Pruning cutoff |
| `BACKUP_RUN_ON_STARTUP` | `0` | Set to `1` for first-boot / test runs |

### Operational affordances

- `make backup-now` — run one on demand
- `make backup-list` — show recent backups in S3
- `make logs svc=db-backup` — tail the backup log
- **`docs/backup-restore.md`** — full restore procedure, disaster recovery, troubleshooting, staging advice

## Test plan

- [ ] `docker compose up -d db-backup` builds and starts cleanly.
- [ ] With `BACKUP_RUN_ON_STARTUP=1` set in `.env`, the container runs a backup on boot and logs each step (`starting pg_dump`, `dumped ...`, `uploading to s3://...`, `done`).
- [ ] The uploaded object is a valid gzipped SQL file (`aws s3 cp s3://.../chess-*.sql.gz - | gunzip | head` shows `CREATE TABLE` statements).
- [ ] `make backup-list` lists it.
- [ ] Set `BACKUP_KEEP_DAYS=0`, run again — old backups get deleted.
- [ ] Restore into a staging database following `docs/backup-restore.md` and verify row counts match.
- [ ] After deploy to prod, verify the 03:00 UTC run happens on schedule.

## Out of scope

- **Monitoring / alerting on missed backups.** Deferred until #27 (Sentry) lands — the cron check-in will be a one-liner then.
- **Point-in-time recovery (WAL archiving).** Daily snapshots are sufficient for this project's scale.
- **Cross-region replication.** One-bucket strategy for v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a background database backup service with configurable UTC schedule, retention window, and optional immediate run-on-startup.
  * Uploads backups to S3-compatible storage and provides commands to trigger an immediate backup and list stored backups.
  * Backup activity is written to container logs for observability.

* **Documentation**
  * New backup & restore guide with configuration, step-by-step restore procedure, operational commands, and disaster-recovery checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->