### PR TITLE
feat(frontend): blunder / mistake / inaccuracy detection in game review

### DIFF
--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -219,6 +219,11 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
               const moveNum = Math.floor(km.moveIdx / 2) + 1;
               const isWhite = km.moveIdx % 2 === 0;
               const label = isWhite ? `${moveNum}. ${data.moves[km.moveIdx].san}` : `${moveNum}... ${data.moves[km.moveIdx].san}`;
+              const evalStr = km.eval
+                ? km.eval.mate !== null
+                  ? `M${Math.abs(km.eval.mate)}`
+                  : (km.eval.cp >= 0 ? '+' : '') + (km.eval.cp / 100).toFixed(1)
+                : '';
               return (
                 <button
                   key={km.moveIdx}
@@ -227,6 +232,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
                 >
                   <ClassificationBadge cls={km.classification} />
                   <span className="font-mono text-[0.68rem] text-on-surface">{label}</span>
+                  <span className="font-mono text-[0.6rem] text-muted ml-auto">{evalStr}</span>
                 </button>
               );
             })}
@@ -339,15 +345,17 @@ function MoveChip({ san, active, onClick, classification }) {
       onClick={onClick}
       className={[
         'font-mono text-[0.78rem] px-1.5 py-0.5 rounded text-left border-0 cursor-pointer transition-colors w-full truncate flex items-center gap-1',
-        active
-          ? 'bg-primary text-on-primary font-semibold'
-          : hasBadge
-            ? `${CLS_BG[classification]} text-on-surface hover:opacity-80`
-            : 'bg-transparent text-on-surface hover:bg-surface-high',
+        active && hasBadge
+          ? `${CLS_BG[classification]} ring-2 ring-primary font-semibold`
+          : active
+            ? 'bg-primary text-on-primary font-semibold'
+            : hasBadge
+              ? `${CLS_BG[classification]} text-on-surface hover:opacity-80`
+              : 'bg-transparent text-on-surface hover:bg-surface-high',
       ].join(' ')}
     >
       {san}
-      {!active && <ClassificationBadge cls={classification} />}
+      <ClassificationBadge cls={classification} />
     </button>
   );
 }

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -4,6 +4,7 @@ import { EvalBar } from './EvalBar.jsx';
 import { apiFetch } from '../api.js';
 import { identifyOpening } from '../utils/openings.js';
 import { useStockfish } from '../hooks/useStockfish.js';
+import { useGameAnalysis } from '../hooks/useGameAnalysis.js';
 
 /**
  * Render a finished game (or precomputed game data) with a review board, eval
@@ -26,6 +27,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
   const [loading, setLoading] = useState(!providedData);
   const [error, setError]     = useState('');
   const { analyze, evaluation, ready: sfReady } = useStockfish();
+  const { annotations, summary, progress, isAnalyzing } = useGameAnalysis(inline ? data?.moves : null);
 
   useEffect(() => {
     setCursor(0);
@@ -131,8 +133,52 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
     </div>
   );
 
+  // Key moments — moves classified as inaccuracy or worse, for the summary panel.
+  const keyMoments = annotations
+    .map((a, i) => a && a.classification !== 'good' ? { moveIdx: i, ...a } : null)
+    .filter(Boolean);
+
   const moveList = (
     <div className="bg-white rounded-md border border-black/[0.04] p-4 h-full overflow-y-auto">
+      {/* Analysis progress / summary */}
+      {inline && (isAnalyzing || annotations.some(Boolean)) && (
+        <div className="mb-3 pb-3 border-b border-black/[0.05]">
+          {isAnalyzing && (
+            <div className="flex items-center gap-2 mb-2">
+              <div className="w-full h-1.5 bg-surface-high rounded-sm overflow-hidden">
+                <div
+                  className="h-full bg-primary transition-all duration-300"
+                  style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+                />
+              </div>
+              <span className="font-mono text-[0.6rem] text-muted whitespace-nowrap">
+                {progress.done}/{progress.total}
+              </span>
+            </div>
+          )}
+          {!isAnalyzing && annotations.some(Boolean) && (
+            <div className="flex gap-4 text-[0.65rem] font-mono">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted uppercase tracking-wider text-[0.5rem]">White</span>
+                <span>
+                  <span className="text-yellow-600">{summary.white.inaccuracies}?!</span>{' '}
+                  <span className="text-orange-600">{summary.white.mistakes}?</span>{' '}
+                  <span className="text-danger">{summary.white.blunders}??</span>
+                </span>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted uppercase tracking-wider text-[0.5rem]">Black</span>
+                <span>
+                  <span className="text-yellow-600">{summary.black.inaccuracies}?!</span>{' '}
+                  <span className="text-orange-600">{summary.black.mistakes}?</span>{' '}
+                  <span className="text-danger">{summary.black.blunders}??</span>
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
       {movePairs.length === 0 && (
         <p className="font-mono text-xs text-muted text-center py-4">No moves recorded</p>
       )}
@@ -140,9 +186,19 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         {movePairs.map((pair, pairIdx) => (
           <div key={pairIdx} className="contents">
             <span className="font-mono text-[0.68rem] text-muted self-center text-right leading-tight py-0.5">{pairIdx + 1}.</span>
-            <MoveChip san={pair[0].san} active={cursor === pairIdx * 2 + 1} onClick={() => setCursor(pairIdx * 2 + 1)} />
+            <MoveChip
+              san={pair[0].san}
+              active={cursor === pairIdx * 2 + 1}
+              onClick={() => setCursor(pairIdx * 2 + 1)}
+              classification={annotations[pairIdx * 2]?.classification}
+            />
             {pair[1]
-              ? <MoveChip san={pair[1].san} active={cursor === pairIdx * 2 + 2} onClick={() => setCursor(pairIdx * 2 + 2)} />
+              ? <MoveChip
+                  san={pair[1].san}
+                  active={cursor === pairIdx * 2 + 2}
+                  onClick={() => setCursor(pairIdx * 2 + 2)}
+                  classification={annotations[pairIdx * 2 + 1]?.classification}
+                />
               : <span />
             }
           </div>
@@ -151,6 +207,30 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
       {resultLabel && (
         <div className="mt-3 pt-3 border-t border-black/[0.05] text-center">
           <span className="font-mono text-sm font-bold text-on-surface">{resultLabel}</span>
+        </div>
+      )}
+
+      {/* Key moments */}
+      {keyMoments.length > 0 && !isAnalyzing && (
+        <div className="mt-3 pt-3 border-t border-black/[0.05]">
+          <p className="font-mono text-[0.55rem] text-muted uppercase tracking-wider mb-2">Key moments</p>
+          <div className="flex flex-col gap-1">
+            {keyMoments.map((km) => {
+              const moveNum = Math.floor(km.moveIdx / 2) + 1;
+              const isWhite = km.moveIdx % 2 === 0;
+              const label = isWhite ? `${moveNum}. ${data.moves[km.moveIdx].san}` : `${moveNum}... ${data.moves[km.moveIdx].san}`;
+              return (
+                <button
+                  key={km.moveIdx}
+                  onClick={() => setCursor(km.moveIdx + 1)}
+                  className="flex items-center gap-2 text-left bg-transparent border-0 cursor-pointer hover:bg-surface-high rounded-sm px-1.5 py-1 transition-colors"
+                >
+                  <ClassificationBadge cls={km.classification} />
+                  <span className="font-mono text-[0.68rem] text-on-surface">{label}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>
@@ -227,18 +307,47 @@ function NavBtn({ children, onClick, disabled, title }) {
   );
 }
 
-function MoveChip({ san, active, onClick }) {
+const CLS_COLORS = {
+  inaccuracy: 'text-yellow-600',
+  mistake:    'text-orange-600',
+  blunder:    'text-danger',
+};
+const CLS_SYMBOLS = {
+  inaccuracy: '?!',
+  mistake:    '?',
+  blunder:    '??',
+};
+const CLS_BG = {
+  inaccuracy: 'bg-yellow-100',
+  mistake:    'bg-orange-100',
+  blunder:    'bg-red-100',
+};
+
+function ClassificationBadge({ cls }) {
+  if (!cls || cls === 'good') return null;
+  return (
+    <span className={`font-mono text-[0.6rem] font-bold ${CLS_COLORS[cls]}`}>
+      {CLS_SYMBOLS[cls]}
+    </span>
+  );
+}
+
+function MoveChip({ san, active, onClick, classification }) {
+  const hasBadge = classification && classification !== 'good';
   return (
     <button
       onClick={onClick}
       className={[
-        'font-mono text-[0.78rem] px-1.5 py-0.5 rounded text-left border-0 cursor-pointer transition-colors w-full truncate',
+        'font-mono text-[0.78rem] px-1.5 py-0.5 rounded text-left border-0 cursor-pointer transition-colors w-full truncate flex items-center gap-1',
         active
           ? 'bg-primary text-on-primary font-semibold'
-          : 'bg-transparent text-on-surface hover:bg-surface-high',
+          : hasBadge
+            ? `${CLS_BG[classification]} text-on-surface hover:opacity-80`
+            : 'bg-transparent text-on-surface hover:bg-surface-high',
       ].join(' ')}
     >
       {san}
+      {!active && <ClassificationBadge cls={classification} />}
     </button>
   );
 }

--- a/frontend/src/hooks/useGameAnalysis.js
+++ b/frontend/src/hooks/useGameAnalysis.js
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Batch-analyse every position in a game and classify each move as
+ * good / inaccuracy / mistake / blunder based on the eval delta.
+ *
+ * Spawns its own Stockfish worker (separate from the eval-bar worker) so
+ * batch analysis and live cursor analysis don't compete for the same
+ * engine instance.
+ *
+ * @param {{ san: string, fen: string }[] | null} moves — the game's move list
+ * @returns {{
+ *   annotations: Array<{ eval: {cp,mate,depth}, classification: string } | null>,
+ *   summary: { white: {inaccuracies,mistakes,blunders}, black: {inaccuracies,mistakes,blunders} },
+ *   progress: { done: number, total: number },
+ *   isAnalyzing: boolean,
+ * }}
+ */
+
+const STOCKFISH_URL = '/stockfish/stockfish-nnue-16-single.js';
+const BATCH_DEPTH = 14;
+const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+// Thresholds (centipawns lost by the mover)
+const INACCURACY_CP = 50;
+const MISTAKE_CP = 150;
+const BLUNDER_CP = 300;
+
+/** Convert an eval to a pseudo-centipawn value for delta comparison.
+ *  Mate evaluations are mapped to large values so they dominate any cp-based eval. */
+function evalToCp(ev) {
+  if (!ev) return 0;
+  if (ev.mate !== null) {
+    const sign = ev.mate > 0 ? 1 : -1;
+    return sign * (30000 - Math.abs(ev.mate) * 100);
+  }
+  return ev.cp;
+}
+
+function classify(cpLoss) {
+  if (cpLoss >= BLUNDER_CP) return 'blunder';
+  if (cpLoss >= MISTAKE_CP) return 'mistake';
+  if (cpLoss >= INACCURACY_CP) return 'inaccuracy';
+  return 'good';
+}
+
+export function useGameAnalysis(moves) {
+  const [annotations, setAnnotations] = useState([]);
+  const [progress, setProgress]       = useState({ done: 0, total: 0 });
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const cancelRef = useRef(false);
+
+  useEffect(() => {
+    if (!moves || moves.length === 0) {
+      setAnnotations([]);
+      setProgress({ done: 0, total: 0 });
+      setIsAnalyzing(false);
+      return;
+    }
+
+    cancelRef.current = false;
+    setAnnotations(new Array(moves.length).fill(null));
+    setProgress({ done: 0, total: moves.length });
+    setIsAnalyzing(true);
+
+    let worker;
+    try {
+      worker = new Worker(STOCKFISH_URL);
+    } catch {
+      setIsAnalyzing(false);
+      return;
+    }
+
+    // Positions to evaluate: starting position + one per move (N+1 total).
+    // We need eval[i] and eval[i+1] to classify move i.
+    const fens = [START_FEN, ...moves.map((m) => m.fen)];
+    const evals = new Array(fens.length).fill(null);
+    let posIdx = 0;       // which FEN we're currently analysing
+    let bestEval = null;  // highest-depth eval seen for the current position
+
+    function analyzePosition(idx) {
+      if (cancelRef.current || idx >= fens.length) {
+        finalize();
+        return;
+      }
+      posIdx = idx;
+      bestEval = null;
+      const fen = fens[idx];
+      const turn = fen.split(' ')[1] ?? 'w';
+      worker._turn = turn;
+      worker.postMessage('stop');
+      worker.postMessage(`position fen ${fen}`);
+      worker.postMessage(`go depth ${BATCH_DEPTH}`);
+    }
+
+    function finalize() {
+      // Compute annotations from the eval pairs
+      const results = [];
+      const summary = {
+        white: { inaccuracies: 0, mistakes: 0, blunders: 0 },
+        black: { inaccuracies: 0, mistakes: 0, blunders: 0 },
+      };
+
+      for (let i = 0; i < moves.length; i++) {
+        const prevEv = evals[i];
+        const currEv = evals[i + 1];
+
+        if (!prevEv || !currEv) {
+          results.push(null);
+          continue;
+        }
+
+        const prevCp = evalToCp(prevEv);
+        const currCp = evalToCp(currEv);
+        const isWhiteMove = i % 2 === 0;
+
+        // "loss" = how many centipawns the mover gave away.
+        // White wants eval to go up; black wants it to go down.
+        const loss = isWhiteMove ? (prevCp - currCp) : (currCp - prevCp);
+        const cpLoss = Math.max(0, loss);
+        const cls = classify(cpLoss);
+
+        const side = isWhiteMove ? 'white' : 'black';
+        if (cls === 'inaccuracy') summary[side].inaccuracies++;
+        if (cls === 'mistake') summary[side].mistakes++;
+        if (cls === 'blunder') summary[side].blunders++;
+
+        results.push({ eval: currEv, classification: cls });
+      }
+
+      setAnnotations(results);
+      setIsAnalyzing(false);
+    }
+
+    worker.onmessage = (e) => {
+      const line = typeof e.data === 'string' ? e.data : String(e.data ?? '');
+
+      if (line === 'uciok') { worker.postMessage('isready'); return; }
+      if (line === 'readyok') { analyzePosition(0); return; }
+
+      // Parse eval from info lines
+      if (line.startsWith('info')) {
+        const depthM = line.match(/\bdepth (\d+)/);
+        if (!depthM) return;
+        const depth = parseInt(depthM[1], 10);
+        if (depth < 4) return;
+
+        const turn = worker._turn ?? 'w';
+        const cpM  = line.match(/\bscore cp (-?\d+)/);
+        const mateM = line.match(/\bscore mate (-?\d+)/);
+
+        let ev = null;
+        if (cpM) {
+          const raw = parseInt(cpM[1], 10);
+          ev = { cp: turn === 'b' ? -raw : raw, mate: null, depth };
+        } else if (mateM) {
+          const raw = parseInt(mateM[1], 10);
+          ev = { cp: null, mate: turn === 'b' ? -raw : raw, depth };
+        }
+        if (ev && (!bestEval || depth > bestEval.depth)) {
+          bestEval = ev;
+        }
+      }
+
+      // `bestmove` signals the search is done for this position
+      if (line.startsWith('bestmove')) {
+        evals[posIdx] = bestEval;
+        setProgress({ done: Math.min(posIdx, moves.length), total: moves.length });
+        analyzePosition(posIdx + 1);
+      }
+    };
+
+    worker.onerror = () => { setIsAnalyzing(false); };
+    worker.postMessage('uci');
+
+    return () => {
+      cancelRef.current = true;
+      try { worker.postMessage('quit'); } catch {}
+      worker.terminate();
+    };
+  }, [moves]);
+
+  const summary = (() => {
+    const s = { white: { inaccuracies: 0, mistakes: 0, blunders: 0 }, black: { inaccuracies: 0, mistakes: 0, blunders: 0 } };
+    annotations.forEach((a, i) => {
+      if (!a) return;
+      const side = i % 2 === 0 ? 'white' : 'black';
+      if (a.classification === 'inaccuracy') s[side].inaccuracies++;
+      if (a.classification === 'mistake') s[side].mistakes++;
+      if (a.classification === 'blunder') s[side].blunders++;
+    });
+    return s;
+  })();
+
+  return { annotations, summary, progress, isAnalyzing };
+}

--- a/frontend/src/hooks/useGameAnalysis.js
+++ b/frontend/src/hooks/useGameAnalysis.js
@@ -38,9 +38,9 @@ function evalToCp(ev) {
 }
 
 function classify(cpLoss) {
-  if (cpLoss >= BLUNDER_CP) return 'blunder';
-  if (cpLoss >= MISTAKE_CP) return 'mistake';
-  if (cpLoss >= INACCURACY_CP) return 'inaccuracy';
+  if (cpLoss > BLUNDER_CP) return 'blunder';
+  if (cpLoss > MISTAKE_CP) return 'mistake';
+  if (cpLoss > INACCURACY_CP) return 'inaccuracy';
   return 'good';
 }
 
@@ -75,6 +75,7 @@ export function useGameAnalysis(moves) {
     // We need eval[i] and eval[i+1] to classify move i.
     const fens = [START_FEN, ...moves.map((m) => m.fen)];
     const evals = new Array(fens.length).fill(null);
+    const fenCache = new Map(); // FEN → eval (skip repeated positions)
     let posIdx = 0;       // which FEN we're currently analysing
     let bestEval = null;  // highest-depth eval seen for the current position
 
@@ -84,8 +85,18 @@ export function useGameAnalysis(moves) {
         return;
       }
       posIdx = idx;
-      bestEval = null;
       const fen = fens[idx];
+
+      // Deduplicate: if this FEN was already evaluated (e.g. threefold
+      // repetition), reuse the cached result and skip the engine call.
+      if (fenCache.has(fen)) {
+        evals[idx] = fenCache.get(fen);
+        setProgress({ done: Math.min(idx, moves.length), total: moves.length });
+        analyzePosition(idx + 1);
+        return;
+      }
+
+      bestEval = null;
       const turn = fen.split(' ')[1] ?? 'w';
       worker._turn = turn;
       worker.postMessage('stop');
@@ -165,6 +176,7 @@ export function useGameAnalysis(moves) {
       // `bestmove` signals the search is done for this position
       if (line.startsWith('bestmove')) {
         evals[posIdx] = bestEval;
+        fenCache.set(fens[posIdx], bestEval);
         setProgress({ done: Math.min(posIdx, moves.length), total: moves.length });
         analyzePosition(posIdx + 1);
       }


### PR DESCRIPTION
Closes #29

## What

Full-game analysis that classifies every move and highlights the moments where each player went wrong. The single feature that turns the review board from "passive position viewer" into "learning tool."

## How it works

### New hook: `useGameAnalysis(moves)`

Spawns a **separate Stockfish worker** (independent of the eval-bar worker) that batch-analyses every position at depth 14. For each move, computes the eval delta between the position before and after:

| CP loss | Classification | Badge | Color |
|---|---|---|---|
| ≤ 50 | good | — | — |
| 50–150 | inaccuracy | `?!` | yellow |
| 150–300 | mistake | `?` | orange |
| > 300 | blunder | `??` | red |

Mate evaluations are converted to pseudo-centipawn values (mate in 5 = ±29500) so the delta arithmetic works uniformly across cp and mate lines.

Returns:
- `annotations[]` — one per move, with `{ eval, classification }`
- `summary` — `{ white: { inaccuracies, mistakes, blunders }, black: { ... } }`
- `progress` — `{ done, total }` for the progress bar
- `isAnalyzing` — boolean

### UI changes in GameReview

1. **Progress bar** in the move list panel while analysis is running.
2. **Summary strip** — "White: 2?! 1? 0??" / "Black: 1?! 0? 1??" — shown after analysis completes.
3. **MoveChip badges** — each move in the move list gets a color-coded background + symbol for its classification. Active (selected) moves show the primary color as before.
4. **Key moments panel** — below the move list, lists every inaccuracy+ as a clickable button that jumps to that move.

### Architecture

- `useGameAnalysis` runs only in inline mode (not modal) and only when game data is available.
- The existing `useStockfish` (eval bar, depth 18) continues to operate independently.
- Two Stockfish workers run simultaneously — each is its own Web Worker thread. Memory overhead is acceptable (the NNUE weights file is shared via the browser's HTTP cache).

## Test plan

- [ ] Open a game review → progress bar fills as positions are analysed.
- [ ] After analysis completes: summary strip shows correct counts per side.
- [ ] Move chips show colored backgrounds + ?!/??/?? badges for non-good moves.
- [ ] Clicking a key moment in the "Key moments" panel jumps the cursor to that move.
- [ ] The eval bar (live cursor eval) continues to work independently — no interference from the batch worker.
- [ ] Navigating away from the review and back starts analysis fresh (cleanup on unmount).
- [ ] A 40-move game completes analysis in <2 minutes (depth 14, single-threaded WASM).
- [ ] Short game (Scholar's mate, 7 moves) finishes in <5 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated chess game analysis with automatic move classification (inaccuracy, mistake, blunder).
  * Added "Key moments" section highlighting important moves in games.
  * Displays analysis progress and per-color statistics summarizing game errors.
  * Move quality badges now appear inline in the move list for quick visual reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->