### PR TITLE
fix(frontend): mobile responsiveness — sidebar drawer + adaptive layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,6 +66,7 @@ export default function App() {
   const [joiningGame, setJoiningGame]       = useState(false);
   const [copied, setCopied]                 = useState(false);
   const [drawOfferDismissed, setDrawOfferDismissed] = useState(null);
+  const [sidebarOpen, setSidebarOpen]               = useState(false);
   const [viewingGameId, setViewingGameId]           = useState(null);
   const [viewingPlayerId, setViewingPlayerId]       = useState(null);
   const [pgnInput, setPgnInput]                     = useState('');
@@ -387,8 +388,19 @@ export default function App() {
     return (
       <div className="min-h-screen bg-[#f1f2f4] flex">
 
-        {/* ── Sidebar ── */}
-        <aside className="w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40">
+        {/* ── Mobile sidebar overlay ── */}
+        {sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/30 z-30 lg:hidden"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+
+        {/* ── Sidebar — hidden on mobile, fixed drawer on lg+ ── */}
+        <aside className={[
+          'w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40 transition-transform duration-200',
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
+        ].join(' ')}>
           {/* Brand + user */}
           <div className="px-5 pt-7 pb-5">
             <div className="flex items-center gap-2 mb-7">
@@ -413,7 +425,7 @@ export default function App() {
             {NAV_ITEMS.map(({ key, icon, label }) => (
               <button
                 key={key}
-                onClick={() => setLobbyTab(key)}
+                onClick={() => { setLobbyTab(key); setSidebarOpen(false); }}
                 className={[
                   'flex items-center gap-3 py-3 px-3 rounded-md text-left w-full transition-all duration-150 border-0 cursor-pointer',
                   lobbyTab === key
@@ -440,11 +452,19 @@ export default function App() {
         </aside>
 
         {/* ── Main area ── */}
-        <div className="ml-64 flex-1 flex flex-col min-h-screen">
+        <div className="lg:ml-64 flex-1 flex flex-col min-h-screen">
 
           {/* Top header */}
-          <header className="sticky top-0 z-30 bg-[#f1f2f4]/80 backdrop-blur-xl border-b border-black/[0.06] px-10 py-4 flex items-center justify-between">
+          <header className="sticky top-0 z-20 bg-[#f1f2f4]/80 backdrop-blur-xl border-b border-black/[0.06] px-4 lg:px-10 py-4 flex items-center justify-between">
             <div className="flex items-center gap-3">
+              {/* Hamburger — mobile only */}
+              <button
+                onClick={() => setSidebarOpen(true)}
+                className="lg:hidden w-10 h-10 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors"
+                aria-label="Open menu"
+              >
+                ☰
+              </button>
               {(viewingGameId || pgnReviewData) && (
                 <button
                   onClick={handleCloseReview}
@@ -477,7 +497,7 @@ export default function App() {
           </header>
 
           {/* Content */}
-          <main className="flex-1 px-10 py-8 overflow-y-auto">
+          <main className="flex-1 px-4 py-6 lg:px-10 lg:py-8 overflow-y-auto">
 
             {/* ── Game analysis page (existing /history/:id flow) ── */}
             {viewingGameId && (
@@ -547,7 +567,7 @@ export default function App() {
                   ) : (
                     <>
                       {/* Time control cards */}
-                      <div className="grid grid-cols-4 gap-3 mb-5">
+                      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
                         {TC_CARDS.map(({ key, icon, label, tc, sub }) => {
                           const active = tcCategory(timeControl) === key;
                           return (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -397,10 +397,13 @@ export default function App() {
         )}
 
         {/* ── Sidebar — hidden on mobile, fixed drawer on lg+ ── */}
-        <aside className={[
-          'w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40 transition-transform duration-200',
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
-        ].join(' ')}>
+        <aside
+          className={[
+            'w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40 transition-transform duration-200',
+            sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
+          ].join(' ')}
+          aria-hidden={!sidebarOpen ? 'true' : undefined}
+        >
           {/* Brand + user */}
           <div className="px-5 pt-7 pb-5">
             <div className="flex items-center gap-2 mb-7">
@@ -460,7 +463,7 @@ export default function App() {
               {/* Hamburger — mobile only */}
               <button
                 onClick={() => setSidebarOpen(true)}
-                className="lg:hidden w-10 h-10 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors"
+                className="lg:hidden w-11 h-11 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors"
                 aria-label="Open menu"
               >
                 ☰

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,6 +67,15 @@ export default function App() {
   const [copied, setCopied]                 = useState(false);
   const [drawOfferDismissed, setDrawOfferDismissed] = useState(null);
   const [sidebarOpen, setSidebarOpen]               = useState(false);
+
+  // Close mobile drawer on Escape
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    function onKey(e) { if (e.key === 'Escape') setSidebarOpen(false); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOpen]);
+
   const [viewingGameId, setViewingGameId]           = useState(null);
   const [viewingPlayerId, setViewingPlayerId]       = useState(null);
   const [pgnInput, setPgnInput]                     = useState('');
@@ -393,6 +402,7 @@ export default function App() {
           <div
             className="fixed inset-0 bg-black/30 z-30 lg:hidden"
             onClick={() => setSidebarOpen(false)}
+            onKeyDown={(e) => { if (e.key === 'Escape') setSidebarOpen(false); }}
           />
         )}
 
@@ -402,7 +412,6 @@ export default function App() {
             'w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40 transition-transform duration-200',
             sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
           ].join(' ')}
-          aria-hidden={!sidebarOpen ? 'true' : undefined}
         >
           {/* Brand + user */}
           <div className="px-5 pt-7 pb-5">

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -220,7 +220,7 @@ function NavBtn({ children, onClick, disabled, title }) {
       onClick={onClick}
       disabled={disabled}
       title={title}
-      className="w-9 h-9 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
+      className="w-11 h-11 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
     >
       {children}
     </button>


### PR DESCRIPTION
Closes #31

## What

The app was desktop-first — a fixed 256px sidebar and hardcoded paddings that overflow on phone viewports. This PR addresses the highest-impact items.

## Changes

### Sidebar → mobile drawer

- Hidden by default on `< lg` (1024px) via `-translate-x-full`.
- **Hamburger button** (☰) in the header visible on mobile only (`lg:hidden`).
- Semi-transparent overlay behind the drawer; clicking it or selecting a nav item auto-closes.
- On `lg+` the sidebar is fixed as before — no behavioral change on desktop.

### Adaptive layout

| Element | Before | After |
|---|---|---|
| Main area margin | `ml-64` always | `lg:ml-64` (mobile gets full viewport) |
| Header padding | `px-10` | `px-4 lg:px-10` |
| Content padding | `px-10 py-8` | `px-4 py-6 lg:px-10 lg:py-8` |
| Time-control cards | `grid-cols-4` | `grid-cols-2 lg:grid-cols-4` |

### Touch targets

GameReview NavBtn: `w-9 h-9` (36px) → `w-11 h-11` (44px) — meets the 44×44 minimum for accessible tap areas.

## Test plan

- [ ] Desktop (≥1024px): sidebar visible, layout unchanged from before.
- [ ] Mobile (<1024px): sidebar hidden, hamburger visible in header.
- [ ] Tap hamburger → drawer slides in, overlay appears.
- [ ] Tap overlay or a nav item → drawer closes.
- [ ] Time-control cards stack 2-wide on mobile, 4-wide on desktop.
- [ ] No horizontal scroll at 375px (iPhone SE).
- [ ] Nav buttons in game review are ≥44px tap targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile hamburger menu opens a responsive off-canvas sidebar with a dimming overlay; overlay and Escape key close the drawer.
  * Sidebar auto-closes when selecting navigation items for a smoother mobile flow.

* **Style**
  * Adjusted mobile-first spacing and main content offset for responsive layouts.
  * Time-control cards use 2-column grid on mobile; navigation button size increased for visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->