### PR TITLE
feat(frontend): dark mode

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,15 +45,18 @@ function tcCategory(tc) {
 
 // ── App ───────────────────────────────────────────────────────────────────────
 
-function toggleTheme() {
-  const isDark = document.documentElement.classList.toggle('dark');
-  localStorage.setItem('theme', isDark ? 'dark' : 'light');
-}
-
 export default function App() {
   const [token, setToken]               = useState(() => localStorage.getItem('ff_token'));
   const [gameId, setGameId]             = useState(null);
   const [playerColour, setPlayerColour] = useState('white');
+
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'));
+
+  function toggleTheme() {
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+    setIsDark(dark);
+  }
 
   const [authMode, setAuthMode]         = useState('login');
   const [authForm, setAuthForm]         = useState({ email: '', password: '', displayName: '' });
@@ -475,8 +478,9 @@ export default function App() {
               <button
                 onClick={toggleTheme}
                 className="w-10 h-10 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors text-sm"
-                aria-label="Toggle dark mode"
-                title="Toggle dark mode"
+                aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-pressed={isDark}
+                title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
               >
                 {/* Sun in light mode, moon in dark — CSS-driven so no React state needed */}
                 <span className="dark:hidden">🌙</span>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,11 @@ function tcCategory(tc) {
 
 // ── App ───────────────────────────────────────────────────────────────────────
 
+function toggleTheme() {
+  const isDark = document.documentElement.classList.toggle('dark');
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+}
+
 export default function App() {
   const [token, setToken]               = useState(() => localStorage.getItem('ff_token'));
   const [gameId, setGameId]             = useState(null);
@@ -224,7 +229,7 @@ export default function App() {
   const challengeBanner = notifications.length > 0 && (
     <div className="fixed bottom-6 right-6 flex flex-col gap-2 z-[200] max-w-sm w-full">
       {notifications.map((n) => (
-        <div key={n.id} className="flex items-center gap-3 bg-white rounded-md px-4 py-3.5 shadow-[0_8px_32px_rgba(0,0,0,0.12)] border border-surface-high">
+        <div key={n.id} className="flex items-center gap-3 bg-surface-lowest rounded-md px-4 py-3.5 shadow-[0_8px_32px_rgba(0,0,0,0.12)] border border-surface-high">
           <div className="flex flex-col gap-0.5 flex-1 min-w-0">
             <span className="font-display font-bold text-sm text-on-surface">{n.from_name} challenged you!</span>
             <span className="font-mono text-[0.7rem] text-muted">{n.time_control} · Accept to start</span>
@@ -243,14 +248,14 @@ export default function App() {
   if (!token) {
     const isRegister = authMode === 'register';
     return (
-      <div className="min-h-screen bg-white flex overflow-hidden">
+      <div className="min-h-screen bg-surface-lowest flex overflow-hidden">
 
         {/* Left — hero panel */}
         <div className="hidden lg:flex lg:w-[58%] shrink-0 relative overflow-hidden bg-[#0b1120]">
           {/* Chessboard grid texture */}
           <div className="absolute inset-0 grid grid-cols-8 opacity-[0.07] pointer-events-none" style={{ gridTemplateRows: 'repeat(8,1fr)' }}>
             {Array.from({ length: 64 }).map((_, i) => (
-              <div key={i} className={(Math.floor(i / 8) + i) % 2 === 0 ? 'bg-white' : ''} />
+              <div key={i} className={(Math.floor(i / 8) + i) % 2 === 0 ? 'bg-surface-lowest' : ''} />
             ))}
           </div>
           {/* Gradient vignette */}
@@ -263,9 +268,9 @@ export default function App() {
             <span className="font-display font-extrabold text-lg tracking-[-0.02em] text-white/80">FF</span>
 
             <div className="max-w-lg">
-              <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/10 rounded-md px-4 py-1.5 mb-8">
+              <div className="inline-flex items-center gap-2 bg-surface-lowest/10 backdrop-blur-sm border border-white/10 rounded-md px-4 py-1.5 mb-8">
                 <span className="text-white/60 font-mono text-[0.65rem] uppercase tracking-[0.1em]">Glicko-2 Rated</span>
-                <span className="w-1 h-1 rounded-full bg-white/30" />
+                <span className="w-1 h-1 rounded-full bg-surface-lowest/30" />
                 <span className="text-white/60 font-mono text-[0.65rem] uppercase tracking-[0.1em]">Live Games</span>
               </div>
               <h1 className="font-display text-[3.75rem] font-extrabold leading-[1.05] tracking-[-0.03em] text-white mb-6">
@@ -281,7 +286,7 @@ export default function App() {
         </div>
 
         {/* Right — form panel */}
-        <div className="flex-1 flex flex-col items-center justify-center px-8 md:px-16 py-12 bg-white">
+        <div className="flex-1 flex flex-col items-center justify-center px-8 md:px-16 py-12 bg-surface-lowest">
           <div className="w-full max-w-[360px]">
 
             {/* Mobile logo */}
@@ -385,10 +390,10 @@ export default function App() {
     ];
 
     return (
-      <div className="min-h-screen bg-[#f1f2f4] flex">
+      <div className="min-h-screen bg-surface flex">
 
         {/* ── Sidebar ── */}
-        <aside className="w-64 fixed left-0 top-0 h-screen flex flex-col bg-[#f8f9fb] border-r border-black/[0.06] z-40">
+        <aside className="w-64 fixed left-0 top-0 h-screen flex flex-col bg-surface-low border-r border-surface-high z-40">
           {/* Brand + user */}
           <div className="px-5 pt-7 pb-5">
             <div className="flex items-center gap-2 mb-7">
@@ -428,7 +433,7 @@ export default function App() {
           </nav>
 
           {/* Sign out */}
-          <div className="px-3 pb-6 pt-3 border-t border-black/[0.06]">
+          <div className="px-3 pb-6 pt-3 border-t border-surface-high">
             <button
               onClick={handleLogout}
               className="flex items-center gap-3 py-3 px-3 rounded-md text-left w-full transition-all border-0 cursor-pointer text-muted hover:bg-black/[0.05] hover:text-danger"
@@ -443,7 +448,7 @@ export default function App() {
         <div className="ml-64 flex-1 flex flex-col min-h-screen">
 
           {/* Top header */}
-          <header className="sticky top-0 z-30 bg-[#f1f2f4]/80 backdrop-blur-xl border-b border-black/[0.06] px-10 py-4 flex items-center justify-between">
+          <header className="sticky top-0 z-30 bg-surface/80 backdrop-blur-xl border-b border-surface-high px-10 py-4 flex items-center justify-between">
             <div className="flex items-center gap-3">
               {(viewingGameId || pgnReviewData) && (
                 <button
@@ -465,15 +470,28 @@ export default function App() {
                   : null}
               </h1>
             </div>
-            {!viewingGameId && !pgnReviewData && (
+            <div className="flex items-center gap-2">
+              {/* Theme toggle */}
               <button
-                onClick={handleCreateInvite}
-                disabled={creatingInvite}
-                className="flex items-center gap-1.5 bg-primary text-on-primary rounded-md px-5 py-2.5 font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.97] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
+                onClick={toggleTheme}
+                className="w-10 h-10 flex items-center justify-center rounded-md bg-surface-high text-on-surface border-0 cursor-pointer hover:bg-surface-highest transition-colors text-sm"
+                aria-label="Toggle dark mode"
+                title="Toggle dark mode"
               >
-                <span className="text-lg leading-none">+</span> New Game
+                {/* Sun in light mode, moon in dark — CSS-driven so no React state needed */}
+                <span className="dark:hidden">🌙</span>
+                <span className="hidden dark:inline">☀️</span>
               </button>
-            )}
+              {!viewingGameId && !pgnReviewData && (
+                <button
+                  onClick={handleCreateInvite}
+                  disabled={creatingInvite}
+                  className="flex items-center gap-1.5 bg-primary text-on-primary rounded-md px-5 py-2.5 font-display font-bold text-sm border-0 cursor-pointer hover:opacity-90 active:scale-[0.97] transition-all shadow-lg shadow-primary/20 disabled:opacity-50"
+                >
+                  <span className="text-lg leading-none">+</span> New Game
+                </button>
+              )}
+            </div>
           </header>
 
           {/* Content */}
@@ -514,7 +532,7 @@ export default function App() {
               <div className="max-w-[1100px] mx-auto grid grid-cols-12 gap-6">
 
                 {/* Match card */}
-                <section className="col-span-12 lg:col-span-7 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
+                <section className="col-span-12 lg:col-span-7 bg-surface-lowest rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-surface-high/50 p-8">
                   <p className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.1em] mb-1">
                     {createdInvite ? 'Share with your opponent' : 'Start a game'}
                   </p>
@@ -524,7 +542,7 @@ export default function App() {
 
                   {createdInvite ? (
                     <div className="flex flex-col gap-4">
-                      <div className="flex items-center gap-3 p-4 bg-[#f1f2f4] rounded-md">
+                      <div className="flex items-center gap-3 p-4 bg-surface rounded-md">
                         <span className="font-mono text-xs text-on-surface flex-1 break-all leading-relaxed">
                           {`${location.origin}/play/${createdInvite.token}`}
                         </span>
@@ -558,7 +576,7 @@ export default function App() {
                                 'flex flex-col gap-2.5 p-4 rounded-lg text-left border-2 transition-all duration-150 cursor-pointer',
                                 active
                                   ? 'bg-primary border-primary text-on-primary shadow-md shadow-primary/20'
-                                  : 'bg-[#f1f2f4] border-transparent hover:border-primary/25 hover:bg-white',
+                                  : 'bg-surface border-transparent hover:border-primary/25 hover:bg-surface-lowest',
                               ].join(' ')}
                             >
                               <span className="text-xl leading-none">{icon}</span>
@@ -572,7 +590,7 @@ export default function App() {
                       </div>
 
                       {/* Custom TC */}
-                      <div className="flex items-center gap-3 mb-5 p-3 bg-[#f1f2f4] rounded-md">
+                      <div className="flex items-center gap-3 mb-5 p-3 bg-surface rounded-md">
                         <span className="font-mono text-[0.62rem] text-muted uppercase tracking-[0.07em] whitespace-nowrap">Custom:</span>
                         <select
                           className="flex-1 bg-transparent border-0 outline-none font-body text-sm text-on-surface cursor-pointer"
@@ -605,18 +623,18 @@ export default function App() {
                 </section>
 
                 {/* Profile ratings card */}
-                <section className="col-span-12 lg:col-span-5 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] overflow-hidden">
+                <section className="col-span-12 lg:col-span-5 bg-surface-lowest rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-surface-high/50 overflow-hidden">
                   <ProfilePanel token={token} user={user} />
                 </section>
 
                 {/* Join game strip */}
-                <section className="col-span-12 bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] px-8 py-6">
+                <section className="col-span-12 bg-surface-lowest rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-surface-high/50 px-8 py-6">
                   <h2 className="font-display font-bold text-base text-on-surface mb-4">Join a game</h2>
                   <form onSubmit={handleJoin} className="flex items-end gap-3">
                     <div className="flex flex-col gap-1.5 flex-1">
                       <label className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.07em]">Invite token or game ID</label>
                       <input
-                        className="px-4 py-3 bg-[#f1f2f4] rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
+                        className="px-4 py-3 bg-surface rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
                         placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                         value={joinInput}
                         onChange={(e) => setJoinInput(e.target.value)}
@@ -653,7 +671,7 @@ export default function App() {
             {/* ── Analyze tab — paste a PGN ── */}
             {!viewingGameId && !pgnReviewData && lobbyTab === 'analyze' && (
               <div className="max-w-2xl mx-auto">
-                <div className="bg-white rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-black/[0.04] p-8">
+                <div className="bg-surface-lowest rounded-md shadow-[0_2px_16px_rgba(0,0,0,0.05)] border border-surface-high/50 p-8">
                   <p className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.1em] mb-1">
                     Paste a PGN
                   </p>
@@ -665,7 +683,7 @@ export default function App() {
                   </p>
                   <textarea
                     aria-labelledby="analyze-heading"
-                    className="w-full min-h-[260px] px-4 py-3 bg-[#f1f2f4] rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all resize-y"
+                    className="w-full min-h-[260px] px-4 py-3 bg-surface rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all resize-y"
                     placeholder={'[Event "Casual game"]\n[White "Player A"]\n[Black "Player B"]\n[Result "1-0"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 ...'}
                     value={pgnInput}
                     onChange={(e) => { setPgnInput(e.target.value); setPgnError(''); }}
@@ -741,7 +759,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-surface flex flex-col">
       {/* Top bar */}
-      <header className="flex items-center justify-between px-6 py-4 bg-white border-b border-surface-high">
+      <header className="flex items-center justify-between px-6 py-4 bg-surface-lowest border-b border-surface-high">
         <div className="flex items-center gap-2">
           <span className="text-lg select-none">♟</span>
           <span className="font-display font-bold text-base text-on-surface tracking-[-0.01em]">Fianchetto Friends</span>
@@ -862,7 +880,7 @@ export default function App() {
 function Overlay({ children }) {
   return (
     <div className="fixed inset-0 bg-surface-low/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-md p-8 shadow-[0_24px_64px_rgba(0,0,0,0.12)] max-w-sm w-full flex flex-col gap-2">
+      <div className="bg-surface-lowest rounded-md p-8 shadow-[0_24px_64px_rgba(0,0,0,0.12)] max-w-sm w-full flex flex-col gap-2">
         {children}
       </div>
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,7 +54,7 @@ export default function App() {
 
   function toggleTheme() {
     const dark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', dark ? 'dark' : 'light');
+    try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch { /* quota / private mode */ }
     setIsDark(dark);
   }
 

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -25,7 +25,7 @@ export function Board({ fen, playerColour, onMove, gameOver, animated = true, ma
 
   return (
     <div
-      className="bg-white rounded-md p-3 shadow-[0_8px_40px_rgba(0,0,0,0.10)] w-full border border-surface-high"
+      className="bg-surface-lowest rounded-md p-3 shadow-[0_8px_40px_rgba(0,0,0,0.10)] w-full border border-surface-high"
       style={{ maxWidth }}
     >
       <Chessboard

--- a/frontend/src/components/Clock.jsx
+++ b/frontend/src/components/Clock.jsx
@@ -89,7 +89,7 @@ export function Clock({ serverMs, active, label }) {
     <div className={[
       'flex flex-col gap-0.5 px-4 py-3 rounded-md min-w-[120px] transition-all duration-300',
       active
-        ? 'bg-white border border-surface-high shadow-[0_2px_12px_rgba(0,0,0,0.08)]'
+        ? 'bg-surface-lowest border border-surface-high shadow-[0_2px_12px_rgba(0,0,0,0.08)]'
         : 'bg-surface-low border border-transparent',
       active && isLow ? 'border-danger/30' : '',
     ].join(' ')}>

--- a/frontend/src/components/EvalBar.jsx
+++ b/frontend/src/components/EvalBar.jsx
@@ -40,7 +40,7 @@ export function EvalBar({ evaluation, orientation = 'white' }) {
       {/* Bar — owns the full stretched height. Depth badge and eval label
           are absolutely positioned inside so they don't eat into the bar's
           height (which must match the board exactly). */}
-      <div className="relative w-full h-full rounded-sm overflow-hidden flex flex-col border border-black/10">
+      <div className="relative w-full h-full rounded-sm overflow-hidden flex flex-col border border-surface-high">
         {/* Top portion (black's side) */}
         <div
           className="bg-[#1c1c1c] transition-all duration-300 ease-out"

--- a/frontend/src/components/ExternalAccounts.jsx
+++ b/frontend/src/components/ExternalAccounts.jsx
@@ -90,14 +90,14 @@ export function ExternalAccounts({ token, onSelectAccount }) {
   return (
     <div className="flex flex-col gap-6">
       {/* Link form */}
-      <div className="bg-white rounded-md border border-black/[0.04] p-6">
+      <div className="bg-surface-lowest rounded-md border border-surface-high/50 p-6">
         <h3 className="font-display font-bold text-base text-on-surface mb-4">Link an account</h3>
         <form onSubmit={handleLink} className="flex items-end gap-3">
           <div className="flex flex-col gap-1.5">
             <label htmlFor="ext-platform" className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.07em]">Platform</label>
             <select
               id="ext-platform"
-              className="px-3 py-2.5 bg-[#f1f2f4] rounded-md border-0 outline-none font-body text-sm text-on-surface cursor-pointer"
+              className="px-3 py-2.5 bg-surface rounded-md border-0 outline-none font-body text-sm text-on-surface cursor-pointer"
               value={platform}
               onChange={(e) => setPlatform(e.target.value)}
             >
@@ -110,7 +110,7 @@ export function ExternalAccounts({ token, onSelectAccount }) {
             <label htmlFor="ext-username" className="font-mono text-[0.6rem] text-muted uppercase tracking-[0.07em]">Username</label>
             <input
               id="ext-username"
-              className="px-4 py-2.5 bg-[#f1f2f4] rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
+              className="px-4 py-2.5 bg-surface rounded-md border-0 outline-none focus:ring-2 focus:ring-primary/30 font-mono text-xs text-on-surface placeholder:text-muted/50 transition-all"
               placeholder="e.g. DrNykterstein"
               value={username}
               onChange={(e) => { setUsername(e.target.value); setLinkError(''); }}
@@ -150,7 +150,7 @@ export function ExternalAccounts({ token, onSelectAccount }) {
             const isSyncing = syncing === acct.id;
             const result = syncResult?.id === acct.id ? syncResult : null;
             return (
-              <div key={acct.id} className="bg-white rounded-md border border-black/[0.04] p-5 flex items-center gap-4">
+              <div key={acct.id} className="bg-surface-lowest rounded-md border border-surface-high/50 p-5 flex items-center gap-4">
                 <span className="text-2xl">{platformInfo?.icon ?? '?'}</span>
                 <div className="flex-1 min-w-0">
                   <p className="font-display font-bold text-sm text-on-surface">{acct.username}</p>

--- a/frontend/src/components/ExternalGames.jsx
+++ b/frontend/src/components/ExternalGames.jsx
@@ -74,7 +74,7 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
               onClick={() => setView(v)}
               className={[
                 'font-body text-xs font-semibold px-3 py-1.5 rounded-sm border-0 cursor-pointer transition-all capitalize',
-                view === v ? 'bg-white text-on-surface shadow-sm' : 'bg-transparent text-muted hover:text-on-surface',
+                view === v ? 'bg-surface-lowest text-on-surface shadow-sm' : 'bg-transparent text-muted hover:text-on-surface',
               ].join(' ')}
             >
               {v}
@@ -104,7 +104,7 @@ export function ExternalGames({ account, token, onViewGame, onBack }) {
             <button
               key={g.id}
               onClick={() => handleViewGame(g.id)}
-              className="bg-white rounded-md border border-black/[0.04] p-4 flex items-center gap-4 w-full text-left cursor-pointer hover:border-primary/20 hover:shadow-sm transition-all"
+              className="bg-surface-lowest rounded-md border border-surface-high/50 p-4 flex items-center gap-4 w-full text-left cursor-pointer hover:border-primary/20 hover:shadow-sm transition-all"
             >
               <div className="w-8 text-center text-lg">
                 {resultBadge(g.result, g.player_color)}

--- a/frontend/src/components/FriendsPanel.jsx
+++ b/frontend/src/components/FriendsPanel.jsx
@@ -127,7 +127,7 @@ export function FriendsPanel({ token, onChallengeAccepted }) {
 
       {/* Challenge card */}
       {challenge && (
-        <div className="flex flex-col gap-3 bg-white rounded-md p-5 border border-primary/20 shadow-[0_2px_12px_rgba(0,90,183,0.08)]">
+        <div className="flex flex-col gap-3 bg-surface-lowest rounded-md p-5 border border-primary/20 shadow-[0_2px_12px_rgba(0,90,183,0.08)]">
           {challenge.invite ? (
             <>
               <div className="flex items-center gap-2">
@@ -252,7 +252,7 @@ function SectionTitle({ children }) {
 function UserRow({ name, rating, sub, children }) {
   const initial = (name ?? '?')[0].toUpperCase();
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md bg-white border border-surface-high shadow-[0_1px_4px_rgba(0,0,0,0.04)]">
+    <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md bg-surface-lowest border border-surface-high shadow-[0_1px_4px_rgba(0,0,0,0.04)]">
       {/* Mini avatar + info */}
       <div className="flex items-center gap-3 flex-1 min-w-0">
         <div className="w-9 h-9 rounded-full bg-primary-gradient text-on-primary font-display font-bold text-sm flex items-center justify-center flex-shrink-0">

--- a/frontend/src/components/GameReview.jsx
+++ b/frontend/src/components/GameReview.jsx
@@ -97,7 +97,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         <span className="font-display font-bold text-base text-on-surface">
           {data.game.white_name} vs {data.game.black_name}
         </span>
-        <span className="font-mono text-xs bg-[#f1f2f4] text-muted px-2.5 py-1 rounded-sm">
+        <span className="font-mono text-xs bg-surface text-muted px-2.5 py-1 rounded-sm">
           {data.game.time_control}
         </span>
         <span className="font-mono text-xs text-primary font-bold">{resultLabel}</span>
@@ -132,7 +132,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
   );
 
   const moveList = (
-    <div className="bg-white rounded-md border border-black/[0.04] p-4 h-full overflow-y-auto">
+    <div className="bg-surface-lowest rounded-md border border-surface-high/50 p-4 h-full overflow-y-auto">
       {movePairs.length === 0 && (
         <p className="font-mono text-xs text-muted text-center py-4">No moves recorded</p>
       )}
@@ -149,7 +149,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         ))}
       </div>
       {resultLabel && (
-        <div className="mt-3 pt-3 border-t border-black/[0.05] text-center">
+        <div className="mt-3 pt-3 border-t border-surface-high/50 text-center">
           <span className="font-mono text-sm font-bold text-on-surface">{resultLabel}</span>
         </div>
       )}
@@ -197,7 +197,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="bg-surface rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-3xl max-h-[92vh] flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-4 bg-white border-b border-surface-high flex-shrink-0">
+        <div className="flex items-center justify-between px-5 py-4 bg-surface-lowest border-b border-surface-high flex-shrink-0">
           {gameInfo ?? <div />}
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-high hover:bg-surface-highest text-muted border-0 cursor-pointer transition-colors flex-shrink-0 ml-3">✕</button>
         </div>
@@ -206,7 +206,7 @@ export function GameReview({ gameId, data: providedData, token, onClose, inline 
         {data && (
           <div className="flex-1 flex flex-col lg:flex-row overflow-hidden">
             <div className="flex flex-col items-center gap-4 p-5 lg:flex-1 overflow-y-auto">{boardAndNav}</div>
-            <div className="lg:w-52 border-t lg:border-t-0 lg:border-l border-surface-high bg-white overflow-y-auto flex-shrink-0 p-3">{moveList}</div>
+            <div className="lg:w-52 border-t lg:border-t-0 lg:border-l border-surface-high bg-surface-lowest overflow-y-auto flex-shrink-0 p-3">{moveList}</div>
           </div>
         )}
       </div>

--- a/frontend/src/components/HistoryPanel.jsx
+++ b/frontend/src/components/HistoryPanel.jsx
@@ -67,10 +67,10 @@ export function HistoryPanel({ token, userId, onViewGame, onViewProfile }) {
         }[outcome];
 
         return (
-          <div
+          <button
             key={g.id}
             onClick={() => onViewGame?.(g.id)}
-            className="flex items-stretch rounded-md bg-surface-lowest border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all"
+            className="flex items-stretch rounded-md bg-surface-lowest border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all w-full text-left"
           >
             {/* Left accent bar */}
             <div className={`w-1 flex-shrink-0 ${outcomeConfig.bar} opacity-80`} />
@@ -104,7 +104,7 @@ export function HistoryPanel({ token, userId, onViewGame, onViewProfile }) {
                 title={`You played ${myColour}`}
               />
             </div>
-          </div>
+          </button>
         );
       })}
 

--- a/frontend/src/components/HistoryPanel.jsx
+++ b/frontend/src/components/HistoryPanel.jsx
@@ -70,7 +70,7 @@ export function HistoryPanel({ token, userId, onViewGame, onViewProfile }) {
           <div
             key={g.id}
             onClick={() => onViewGame?.(g.id)}
-            className="flex items-stretch rounded-md bg-white border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all"
+            className="flex items-stretch rounded-md bg-surface-lowest border border-surface-high overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.05)] cursor-pointer hover:border-primary/30 hover:shadow-[0_2px_12px_rgba(0,90,183,0.08)] transition-all"
           >
             {/* Left accent bar */}
             <div className={`w-1 flex-shrink-0 ${outcomeConfig.bar} opacity-80`} />

--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -24,7 +24,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
   }, [type, token]);
 
   const typeSelector = (
-    <div className="flex gap-1.5 p-1.5 bg-[#f1f2f4] rounded-md w-fit">
+    <div className="flex gap-1.5 p-1.5 bg-surface rounded-md w-fit">
       {TYPES.map((t) => (
         <button
           key={t.key}
@@ -32,7 +32,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
           className={[
             'flex items-center gap-1.5 font-body text-sm px-4 py-2 rounded-md border-0 cursor-pointer transition-all',
             type === t.key
-              ? 'bg-white text-on-surface font-semibold shadow-sm'
+              ? 'bg-surface-lowest text-on-surface font-semibold shadow-sm'
               : 'bg-transparent text-muted hover:text-on-surface',
           ].join(' ')}
         >
@@ -44,7 +44,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
   );
 
   const table = (
-    <div className="bg-white rounded-md border border-black/[0.04] overflow-hidden mt-5">
+    <div className="bg-surface-lowest rounded-md border border-surface-high/50 overflow-hidden mt-5">
       {loading && (
         <div className="flex items-center justify-center py-12">
           <p className="font-body text-sm text-muted">Loading…</p>
@@ -63,7 +63,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
       {data && data.players.length > 0 && (
         <table className="w-full">
           <thead>
-            <tr className="border-b border-black/[0.05]">
+            <tr className="border-b border-surface-high/50">
               <th className="font-mono text-[0.62rem] text-muted uppercase tracking-[0.07em] text-left px-6 py-4 w-12">#</th>
               <th className="font-mono text-[0.62rem] text-muted uppercase tracking-[0.07em] text-left px-2 py-4">Player</th>
               <th className="font-mono text-[0.62rem] text-muted uppercase tracking-[0.07em] text-right px-6 py-4">Rating</th>
@@ -71,7 +71,7 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
           </thead>
           <tbody>
             {data.players.map((p, i) => (
-              <tr key={p.id} className="border-b border-black/[0.04] last:border-0 hover:bg-[#f8f9fb] transition-colors">
+              <tr key={p.id} className="border-b border-surface-high/50 last:border-0 hover:bg-surface-low transition-colors">
                 <td className="px-6 py-4 text-center">
                   {i < 3
                     ? <span className="text-lg leading-none">{MEDALS[i]}</span>
@@ -114,11 +114,11 @@ export function Leaderboard({ token, onClose, onViewProfile, inline = false }) {
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="bg-surface rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-4 bg-white border-b border-surface-high flex-shrink-0">
+        <div className="flex items-center justify-between px-5 py-4 bg-surface-lowest border-b border-surface-high flex-shrink-0">
           <span className="font-display font-bold text-base text-on-surface">Leaderboard</span>
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-high hover:bg-surface-highest text-muted border-0 cursor-pointer transition-colors">✕</button>
         </div>
-        <div className="p-4 bg-white border-b border-surface-high flex-shrink-0">
+        <div className="p-4 bg-surface-lowest border-b border-surface-high flex-shrink-0">
           {typeSelector}
         </div>
         <div className="flex-1 overflow-y-auto p-4">{table}</div>

--- a/frontend/src/components/OpeningTree.jsx
+++ b/frontend/src/components/OpeningTree.jsx
@@ -142,7 +142,7 @@ export function OpeningTree({ accountId, token }) {
                     <button
                       key={m.move}
                       onClick={() => drillDown(m.move)}
-                      className="flex items-center gap-3 p-3 bg-white rounded-md border border-black/[0.04] hover:border-primary/20 hover:shadow-sm transition-all cursor-pointer w-full text-left"
+                      className="flex items-center gap-3 p-3 bg-surface-lowest rounded-md border border-surface-high/50 hover:border-primary/20 hover:shadow-sm transition-all cursor-pointer w-full text-left"
                     >
                       {/* Move */}
                       <span className="font-mono text-sm font-bold text-on-surface w-14 flex-shrink-0">

--- a/frontend/src/components/PlayerProfile.jsx
+++ b/frontend/src/components/PlayerProfile.jsx
@@ -36,7 +36,7 @@ export function PlayerProfile({ userId, token, onClose, onViewGame }) {
       className="fixed inset-0 bg-on-surface/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-white rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
+      <div className="bg-surface-lowest rounded-md shadow-[0_24px_64px_rgba(0,0,0,0.2)] w-full max-w-md max-h-[88vh] flex flex-col overflow-hidden">
 
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-5 border-b border-surface-high flex-shrink-0">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,6 +51,35 @@
   --radius-lg: 0.75rem;
 }
 
+/* ── Dark mode ────────────────────────────────────────────────────────────
+   Class-based (.dark on <html>) so users can override system preference.
+   The toggle in the UI reads/writes localStorage('theme') and falls back
+   to prefers-color-scheme on first visit.                                 */
+.dark {
+  --color-primary:        #4d9eff;
+  --color-primary-end:    #60b0ff;
+  --color-on-primary:     #ffffff;
+
+  --color-surface-lowest:   #14161a;
+  --color-surface:          #1a1d21;
+  --color-surface-low:      #1e2126;
+  --color-surface-high:     #2a2e35;
+  --color-surface-highest:  #353a42;
+
+  --color-on-surface:     #e6e8ec;
+  --color-muted:          #8b9099;
+
+  --color-secondary-fixed: #2a3340;
+  --color-danger:          #ef4444;
+  --color-danger-bg:       #3b1111;
+  --color-success:         #4ade80;
+  --color-success-bg:      #0a2e1a;
+
+  --shadow-ambient: 0 8px 32px rgba(0, 0, 0, 0.2);
+  --shadow-raised:  0 12px 40px rgba(0, 0, 0, 0.3);
+  --shadow-float:   0 8px 40px rgba(0, 0, 0, 0.3);
+}
+
 /* ── Base reset ──────────────────────────────────────────────────────────── */
 @layer base {
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -79,7 +108,7 @@
 /* ── Custom utilities ────────────────────────────────────────────────────── */
 /* In Tailwind v4, @utility registers classes usable in JSX and with @apply  */
 @utility bg-primary-gradient {
-  background: linear-gradient(135deg, #005ab7, #0072e5);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-end));
 }
 
 @utility nums-tabular {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,9 +6,13 @@ import App from './App.jsx';
 // Apply dark mode from localStorage or system preference before first paint
 // to avoid a flash of wrong theme. The .dark class on <html> drives the
 // CSS variable overrides in index.css.
-const stored = localStorage.getItem('theme');
-if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-  document.documentElement.classList.add('dark');
+// Guard against missing browser APIs (e.g. SSR / test runners) even though
+// this is a Vite SPA — defensive and costs nothing.
+if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark' || (!stored && window.matchMedia?.('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.classList.add('dark');
+  }
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
 
+// Apply dark mode from localStorage or system preference before first paint
+// to avoid a flash of wrong theme. The .dark class on <html> drives the
+// CSS variable overrides in index.css.
+const stored = localStorage.getItem('theme');
+if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  document.documentElement.classList.add('dark');
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Closes #36

## What

Full dark mode, toggled via a 🌙/☀️ button in the header. System preference respected on first visit; user override persisted in localStorage.

## How

### CSS (index.css)

A `.dark` class on `<html>` overrides every `--color-*` and `--shadow-*` design token:

| Token | Light | Dark |
|---|---|---|
| surface-lowest | `#ffffff` | `#14161a` |
| surface | `#f5f7fb` | `#1a1d21` |
| surface-high | `#e4e8ee` | `#2a2e35` |
| on-surface | `#191c1e` | `#e6e8ec` |
| primary | `#005ab7` | `#4d9eff` |
| danger | `#b91c1c` | `#ef4444` |

`bg-primary-gradient` now uses `var(--color-primary)` instead of hardcoded hex.

### JSX (14 files)

Mass-replaced hardcoded colors with token classes:
- `bg-white` → `bg-surface-lowest` (31 instances)
- `bg-[#f1f2f4]` → `bg-surface` (11)
- `bg-[#f8f9fb]` → `bg-surface-low` (2)
- `border-black/[0.04-0.06]` → `border-surface-high` (17)

### Initialization (main.jsx)

Reads `localStorage('theme')` before React mounts and applies `.dark` immediately to avoid a flash of wrong theme.

### Toggle (App.jsx)

Moon/sun icon button using CSS-driven visibility (`dark:hidden` / `hidden dark:inline`) — no React state or re-render needed for the icon swap. The click handler toggles the class and writes to localStorage.

## Test plan

- [ ] First visit with system dark pref → app renders dark.
- [ ] Click toggle → switches to light, persists across reload.
- [ ] All cards, inputs, panels, sidebar use dark surfaces.
- [ ] Board pieces and squares remain visible (they have their own colors).
- [ ] Eval bar contrast is readable in dark mode.
- [ ] No hardcoded `bg-white` or `bg-[#f...]` left in JSX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle in the lobby to switch light/dark; preference is persisted and applied on load.

* **Style**
  * Replaced many hardcoded light backgrounds/borders with shared design-token surface and border tokens across UI panels, notifications, and modals.
  * Dark-mode token overrides updated so the UI consistently reflects the selected theme.

* **Accessibility**
  * Converted multiple list rows to semantic buttons for improved keyboard and screen-reader interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->